### PR TITLE
fix: wrap long lines in session history detail view

### DIFF
--- a/internal/ui/detail_render.go
+++ b/internal/ui/detail_render.go
@@ -141,13 +141,18 @@ func renderExpandedToolCall(tc *model.ToolCall, maxWidth int) string {
 	headerLine := "  " + name + "  " + StyleDim.Render(inputFull) + "  " + statusStr + durationStr
 
 	var lines []string
-	lines = append(lines, headerLine)
+	lines = append(lines, ansi.Wrap(headerLine, maxWidth, ""))
 
 	// Show full result content
 	resultStr := expandResult(tc)
 	if resultStr != "" {
+		indent := "    "
+		contentWidth := maxWidth - len(indent)
+		if contentWidth < 20 {
+			contentWidth = 20
+		}
 		for _, rl := range strings.Split(resultStr, "\n") {
-			lines = append(lines, "    "+StyleDim.Render(rl))
+			lines = append(lines, indent+ansi.Wrap(StyleDim.Render(rl), contentWidth, ""))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Tool call header lines and result lines in the history-detail view were not wrapped to terminal width, causing text to overflow off-screen
- Applied `ansi.Wrap` to both the tool call header line and each result line (with proper indent accounting)

## Test plan
- [x] `make fmt` — no changes
- [x] `make lint` — 0 issues
- [x] `make test` — all pass
- [x] Visually verify in claudeview that long tool call lines (e.g. ExitPlanMode) now wrap properly in the history-detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)