### PR TITLE
docs: rewrite README with concise, value-first structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,40 @@
-# claudeview
+# claudeview: Terminal Dashboard for Claude Code
 
-Terminal dashboard for Claude Code. Browse sessions, agents, tool calls, tasks, plugins, and MCP servers — all from one place, in real time.
+**What is it?**
 
-## Features
+claudeview is a zero-setup TUI that gives you full observability into Claude Code sessions. It reads `~/.claude/` directly — no hooks, no config, no agents to run. Projects, sessions, agents, tool calls, plugins, and memories are all navigable from a single terminal interface with live-streaming updates.
 
-- **Zero-setup observability** — reads `~/.claude/projects/` JSONL files directly; no hooks, no config, no agents to run
-- **Full session hierarchy** — projects, sessions, agents, tool calls, tasks, plugins, and MCP servers in a single view
-- **Live updates** — transcripts stream in as Claude writes them; no polling delay
-- **Agent tree** — main agent and subagents rendered as a navigable tree with type, status, and last activity
-- **In-place log view** — read the raw transcript of any session or agent without leaving the dashboard
-- **Detail and YAML views** — inspect any row's full data as structured text or raw JSON
+**Core Design**
 
-For the full UI specification, keybindings, and column definitions see [`docs/ui-spec.md`](docs/ui-spec.md).
+The dashboard follows the k9s model: hierarchical drill-down with vim-style navigation. `j/k` to move, `enter` to drill down, `esc` to go back, `/` to filter. Every view refreshes on a 1-second tick, and the history view supports follow mode — auto-scrolling to the latest turn like `tail -f` as Claude writes.
 
-## Installation
+**Key Capabilities**
+
+1. **Session hierarchy** — projects, sessions, agents, and tool calls in a single navigable tree
+2. **Slug grouping** — related sessions (plan/execute transitions sharing a slug) collapse into a single row with aggregated stats and a merged history view separated by divider rows
+3. **Subagent visibility** — full agent tree with types, status, and embedded transcript rendering in the history view
+4. **Live follow mode** — history view streams new turns as they arrive; scroll up to lock position, `G` to re-enable
+5. **Plugin and memory inspection** — jump to plugins (`p`) or memories (`m`) from any view, with state preserved for `esc`-to-restore
+6. **Detail views** — expanded content with thinking blocks, tool call inputs/outputs, and per-model token counts
+
+**Data Model**
+
+claudeview reads directly from Claude Code's local storage:
+
+```
+~/.claude/projects/<hash>/
+├── <session-id>.jsonl              main agent transcript
+└── <session-id>/subagents/
+    └── agent-<id>.jsonl            subagent transcripts
+~/.claude/plugins/                  plugin metadata
+~/.claude/settings.json             MCP server config
+```
+
+Transcript parsing is incremental and offset-based — only new bytes are read on each tick, keeping the dashboard responsive even with large session files.
+
+**Getting Started**
+
+Install the latest release:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Curt-Park/claudeview/main/install.sh | bash
@@ -27,54 +48,21 @@ cd claudeview
 make install
 ```
 
-## Usage
+Then run `claudeview` to start on the projects view, or `claudeview --demo` with synthetic data.
+
+**Development**
+
+The recommended setup uses [mise](https://mise.run) for tool management. After cloning, `mise trust && mise install` handles Go and linter setup. Key targets:
 
 ```bash
-claudeview         # Start on projects view
-claudeview --demo  # Run with synthetic demo data
-```
-
-## Data Sources
-
-claudeview reads directly from `~/.claude/`:
-
-```
-~/.claude/projects/<hash>/
-├── <session-id>.jsonl          ← main agent transcript
-└── <session-id>/subagents/
-    └── agent-<id>.jsonl        ← subagent transcripts
-~/.claude/tasks/<session>/      ← task JSON files
-~/.claude/plugins/              ← plugin metadata
-~/.claude/settings.json         ← MCP server config
-```
-
-## Development Setup
-
-### Recommended: mise
-
-```bash
-curl https://mise.run | sh
-echo 'eval "$(mise activate bash)"' >> ~/.bashrc
-source ~/.bashrc
-
-git clone https://github.com/Curt-Park/claudeview.git
-cd claudeview
-mise trust && mise install
-make build
-```
-
-### Manual
-
-Install Go 1.26+ and golangci-lint, then:
-
-```bash
-make build    # build binary → bin/claudeview
-make test     # run tests
-make bdd      # run BDD integration tests
-make lint     # run golangci-lint
+make build    # build binary
+make test     # run tests with race detector
+make lint     # golangci-lint
 make demo     # build and run demo mode
 ```
 
-## License
+For the full UI specification, keybindings, and column definitions see [`docs/ui-spec.md`](docs/ui-spec.md).
+
+**License**
 
 MIT


### PR DESCRIPTION
## Summary
- Rewrites README to match the autology project's style: bold-header sections, conversational prose, value-first framing
- Highlights zero-setup observability, slug grouping, subagent visibility, live follow mode, and incremental parsing
- Removes verbose tables and redundant sections in favor of concise paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)