### PR TITLE
feat: add --update flag for self-updating binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ cd claudeview
 make install
 ```
 
-Then run `claudeview` to start on the projects view, or `claudeview --demo` with synthetic data.
+Then run `claudeview` to start on the projects view, or `claudeview --demo` with synthetic data. To self-update to the latest release:
+
+```bash
+claudeview --update
+```
 
 **Development**
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,10 +24,7 @@ import (
 // AppVersion is set from main.go via the build-time Version variable.
 var AppVersion string
 
-var (
-	demoMode   bool
-	renderOnce bool
-)
+var demoMode bool
 
 // Execute runs the root command.
 func Execute() {
@@ -50,7 +47,6 @@ Use : to switch resource types (sessions, agents, tools, tasks, plugins, mcp).`,
 
 func init() {
 	rootCmd.Flags().BoolVar(&demoMode, "demo", false, "Run with synthetic demo data")
-	rootCmd.Flags().BoolVar(&renderOnce, "render-once", false, "Render one frame to stdout and exit (for debugging)")
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -65,12 +61,6 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Create top-level model that wraps AppModel with actual view data
 	root := newRootModel(appModel, dp)
-
-	if renderOnce {
-		root.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
-		fmt.Print(root.View())
-		return nil
-	}
 
 	p := tea.NewProgram(root,
 		tea.WithAltScreen(),

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// releaseURL and downloadURL are vars so tests can override them.
+var (
+	releaseURL  = "https://api.github.com/repos/Curt-Park/claudeview/releases/latest"
+	downloadURL = "https://github.com/Curt-Park/claudeview/releases/download/%s/claudeview-%s-%s"
+)
+
+var updateFlag bool
+
+func init() {
+	rootCmd.Flags().BoolVar(&updateFlag, "update", false, "Self-update to the latest GitHub release")
+
+	origRunE := rootCmd.RunE
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if updateFlag {
+			return runSelfUpdate()
+		}
+		return origRunE(cmd, args)
+	}
+}
+
+// githubRelease is the minimal JSON shape from the GitHub releases API.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// fetchLatestRelease queries GitHub for the latest release tag.
+func fetchLatestRelease() (string, error) {
+	resp, err := http.Get(releaseURL) //nolint:gosec,noctx
+	if err != nil {
+		return "", fmt.Errorf("fetching latest release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", fmt.Errorf("decoding release JSON: %w", err)
+	}
+	return rel.TagName, nil
+}
+
+// currentBinaryPath returns the resolved path of the running executable.
+func currentBinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(exe)
+}
+
+// downloadAndReplace fetches the platform binary for tag and atomically
+// replaces the file at binPath.
+func downloadAndReplace(tag, binPath string) error {
+	url := fmt.Sprintf(downloadURL, tag, runtime.GOOS, runtime.GOARCH)
+
+	resp, err := http.Get(url) //nolint:gosec,noctx
+	if err != nil {
+		return fmt.Errorf("downloading binary: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned %d", resp.StatusCode)
+	}
+
+	// Preserve original permissions.
+	info, err := os.Stat(binPath)
+	if err != nil {
+		return fmt.Errorf("stat current binary: %w", err)
+	}
+
+	// Write to temp file in same directory for atomic rename.
+	dir := filepath.Dir(binPath)
+	tmp, err := os.CreateTemp(dir, "claudeview-update-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// Clean up temp file on error; clear path on success to keep new binary.
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, info.Mode()); err != nil {
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, binPath); err != nil {
+		return fmt.Errorf("replacing binary: %w", err)
+	}
+
+	tmpPath = "" // prevent deferred removal of the new binary
+	return nil
+}
+
+// runSelfUpdate checks for the latest release and updates if needed.
+func runSelfUpdate() error {
+	fmt.Println("Checking for updates...")
+
+	tag, err := fetchLatestRelease()
+	if err != nil {
+		return err
+	}
+
+	if AppVersion != "dev" && AppVersion == tag {
+		fmt.Printf("Already up to date (%s).\n", AppVersion)
+		return nil
+	}
+
+	fmt.Printf("Updating %s → %s...\n", AppVersion, tag)
+
+	binPath, err := currentBinaryPath()
+	if err != nil {
+		return fmt.Errorf("locating binary: %w", err)
+	}
+
+	if err := downloadAndReplace(tag, binPath); err != nil {
+		return err
+	}
+
+	fmt.Printf("Updated to %s.\n", tag)
+	return nil
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFetchLatestRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3"}`))
+	}))
+	defer srv.Close()
+
+	old := releaseURL
+	releaseURL = srv.URL
+	defer func() { releaseURL = old }()
+
+	tag, err := fetchLatestRelease()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v1.2.3" {
+		t.Fatalf("got tag %q, want %q", tag, "v1.2.3")
+	}
+}
+
+func TestFetchLatestReleaseHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	old := releaseURL
+	releaseURL = srv.URL
+	defer func() { releaseURL = old }()
+
+	_, err := fetchLatestRelease()
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestDownloadAndReplace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("new-binary-content"))
+	}))
+	defer srv.Close()
+
+	old := downloadURL
+	downloadURL = srv.URL + "/%s/claudeview-%s-%s"
+	defer func() { downloadURL = old }()
+
+	// Create a fake current binary.
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "claudeview")
+	if err := os.WriteFile(binPath, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := downloadAndReplace("v1.2.3", binPath); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new-binary-content" {
+		t.Fatalf("got %q, want %q", data, "new-binary-content")
+	}
+
+	info, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("got permissions %o, want 0755", info.Mode().Perm())
+	}
+}
+
+func TestRunSelfUpdateAlreadyCurrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.0.0"}`))
+	}))
+	defer srv.Close()
+
+	oldRelease := releaseURL
+	releaseURL = srv.URL
+	defer func() { releaseURL = oldRelease }()
+
+	oldVersion := AppVersion
+	AppVersion = "v1.0.0"
+	defer func() { AppVersion = oldVersion }()
+
+	// Should return nil without attempting a download.
+	if err := runSelfUpdate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ claudeview is a Go TUI application for monitoring Claude Code sessions. It reads
 ## Entry Points
 
 - `main.go` — sets `AppVersion` from build-time ldflags, calls `cmd.Execute()`
-- `cmd/root.go` — Cobra CLI; `--demo` and `--render-once` flags; wires `DataProvider` into `AppModel`
+- `cmd/root.go` — Cobra CLI; `--demo` flag; wires `DataProvider` into `AppModel`
 
 ## Top-Level Architecture
 

--- a/docs/cmd-package.md
+++ b/docs/cmd-package.md
@@ -69,7 +69,7 @@ Both implement `ui.DataProvider`:
 | Flag           | Effect                                                     |
 |----------------|------------------------------------------------------------|
 | `--demo`       | Use `demoDataProvider` instead of live filesystem data     |
-| `--render-once`| Render a single frame and exit (for snapshot testing)      |
+| `--update`     | Self-update to the latest GitHub release                   |
 
 ## Helper Functions
 


### PR DESCRIPTION
## Summary

- Add `claudeview --update` for single-command self-update from GitHub releases
- Fetch latest release tag, compare versions, download platform binary, atomic rename
- Remove unused `--render-once` flag (replaced by tmux-based debugging)
- 4 tests using `httptest.NewServer` — no real network calls

## Test plan

- [x] `make fmt` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all pass with race detector
- [ ] Smoke test: `go run -ldflags "-X main.Version=v0.0.1" . --update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)