### PR TITLE
docs: sync knowledge base with --update feature

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,7 @@ claudeview is a Go TUI application for monitoring Claude Code sessions. It reads
 
 - `main.go` — sets `AppVersion` from build-time ldflags, calls `cmd.Execute()`
 - `cmd/root.go` — Cobra CLI; `--demo` flag; wires `DataProvider` into `AppModel`
+- `cmd/update.go` — `--update` flag; self-update from GitHub releases
 
 ## Top-Level Architecture
 

--- a/docs/cmd-package.md
+++ b/docs/cmd-package.md
@@ -10,9 +10,11 @@ Wires all internal packages into a runnable Bubble Tea application. Contains the
 
 ## Files
 
-| File       | Purpose                                                                         |
-|------------|---------------------------------------------------------------------------------|
-| `root.go`  | Cobra `rootCmd`; `rootModel`; `liveDataProvider`; `demoDataProvider`; async load |
+| File              | Purpose                                                                         |
+|-------------------|---------------------------------------------------------------------------------|
+| `root.go`         | Cobra `rootCmd`; `rootModel`; `liveDataProvider`; `demoDataProvider`; async load |
+| `update.go`       | `--update` self-update: fetch latest GitHub release, download, atomic replace    |
+| `update_test.go`  | 4 tests for update logic using `httptest.NewServer` (no network)                |
 
 ## rootModel
 

--- a/docs/test-suite.md
+++ b/docs/test-suite.md
@@ -6,7 +6,7 @@ tags: [testing, ui, internals]
 
 # Test Suite
 
-Tests span four packages. `internal/ui` has the largest test surface (integration + render), while `internal/config`, `internal/model`, and `internal/transcript` each have unit tests for their own logic. The `internal/view` and `internal/demo` packages have no test files.
+Tests span five packages. `internal/ui` has the largest test surface (integration + render), while `cmd`, `internal/config`, `internal/model`, and `internal/transcript` each have unit tests for their own logic. The `internal/view` and `internal/demo` packages have no test files.
 
 ## Test Files — `internal/ui` (`package ui_test`)
 
@@ -25,6 +25,7 @@ Tests span four packages. `internal/ui` has the largest test surface (integratio
 
 | Package                | Files                                        | Count |
 |------------------------|----------------------------------------------|-------|
+| `cmd`                  | `update_test.go`                             | 4     |
 | `internal/config`      | `settings_test.go`, `plugins_test.go`        | ~15   |
 | `internal/model`       | `agent_test.go`, `session_test.go`, `project_test.go`, `tool_call_test.go`, `plugin_test.go`, `resource_test.go`, `turn_test.go`, `slug_group_test.go` | ~52 |
 | `internal/transcript`  | `scanner_test.go`, `parser_test.go` (includes slug extraction tests) | ~13 |


### PR DESCRIPTION
## Summary

- Add `update.go` and `update_test.go` to cmd-package file table
- Update test-suite from "four packages" to five (add `cmd` with 4 tests)
- List `cmd/update.go` as entry point in architecture overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)