### PR TITLE
docs: mention autology for internal documentation sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ make lint     # golangci-lint
 make demo     # build and run demo mode
 ```
 
-For the full UI specification, keybindings, and column definitions see [`docs/ui-spec.md`](docs/ui-spec.md).
+For the full UI specification, keybindings, and column definitions see [`docs/ui-spec.md`](docs/ui-spec.md). Internal documentation under `docs/` is kept in sync with the codebase via [autology](https://github.com/Curt-Park/autology).
 
 **License**
 


### PR DESCRIPTION
## Summary

- Add one-line mention that `docs/` is kept in sync via autology

🤖 Generated with [Claude Code](https://claude.com/claude-code)