### PR TITLE
feat: Claude Max usage limit monitor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,6 +19,7 @@ import (
 	"github.com/Curt-Park/claudeview/internal/provider"
 	"github.com/Curt-Park/claudeview/internal/transcript"
 	"github.com/Curt-Park/claudeview/internal/ui"
+	"github.com/Curt-Park/claudeview/internal/usage"
 	"github.com/Curt-Park/claudeview/internal/view"
 )
 
@@ -66,6 +69,12 @@ func run(cmd *cobra.Command, args []string) error {
 	)
 	_, err := p.Run()
 	return err
+}
+
+// usageLoadedMsg carries freshly loaded usage data back to the UI goroutine.
+type usageLoadedMsg struct {
+	data  *usage.Data
+	stale bool
 }
 
 // dataLoadedMsg carries freshly loaded data back to the UI goroutine.
@@ -124,6 +133,12 @@ type rootModel struct {
 	// historyToolCallID identifies the specific ToolCallRow sub-row; "" means cursor is on the parent.
 	historyCursorKey  string
 	historyToolCallID string
+
+	// Usage bar
+	usageClient *usage.Client
+	usageData   *usage.Data
+	usageStale  bool
+	usageTick   int // increments each tick; refresh at multiples of 60
 }
 
 func newRootModel(app ui.AppModel, dp ui.DataProvider) *rootModel {
@@ -141,6 +156,21 @@ func newRootModel(app ui.AppModel, dp ui.DataProvider) *rootModel {
 		cursor:          make(map[model.ResourceType]struct{ sel, off int }),
 		lastResource:    app.Resource,
 	}
+	// Initialize usage client if credentials are available.
+	credPath := filepath.Join(config.ClaudeDir(), ".credentials.json")
+	if token, err := usage.ReadToken(credPath); err == nil {
+		rm.usageClient = usage.NewClient(token, "")
+		// Fetch immediately so bar shows on first render.
+		if data, stale, err := rm.usageClient.Fetch(context.Background()); err == nil {
+			rm.usageData = data
+			rm.usageStale = stale
+		}
+	}
+	// Demo mode: use synthetic usage data.
+	if demoMode {
+		rm.usageData = demo.GenerateUsage()
+	}
+
 	rm.loadData()
 	return rm
 }
@@ -198,6 +228,9 @@ func (rm *rootModel) syncView() {
 	if h <= 0 {
 		h = 30
 	}
+
+	// Render usage bar (empty string if no data).
+	rm.app.Info.UsageLine = usage.RenderBar(rm.usageData, rm.usageStale, w)
 
 	rm.updateInfo()
 
@@ -303,17 +336,25 @@ func (rm *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		rm.syncView()
 
 	case ui.TickMsg:
-		// Refresh time-based columns (LAST ACTIVE) on every tick
 		rm.syncView()
-		// Trigger async data reload if not already in progress
+		rm.usageTick++
 		if !rm.loading {
 			rm.loading = true
 			extraCmd = rm.loadDataAsync()
+		}
+		// Refresh usage every 60 ticks (≈60 seconds).
+		if rm.usageTick%60 == 0 {
+			extraCmd = tea.Batch(extraCmd, rm.loadUsageAsync())
 		}
 
 	case ui.SyncViewMsg:
 		rm.syncView()
 		return rm, nil
+
+	case usageLoadedMsg:
+		rm.usageData = msg.data
+		rm.usageStale = msg.stale
+		rm.syncView()
 
 	case dataLoadedMsg:
 		rm.loading = false
@@ -434,6 +475,21 @@ func (rm *rootModel) loadDataAsync() tea.Cmd {
 			}
 		}
 		return msg
+	}
+}
+
+// loadUsageAsync returns a tea.Cmd that fetches usage data in a background goroutine.
+func (rm *rootModel) loadUsageAsync() tea.Cmd {
+	if rm.usageClient == nil {
+		return nil
+	}
+	client := rm.usageClient
+	return func() tea.Msg {
+		data, stale, err := client.Fetch(context.Background())
+		if err != nil {
+			return usageLoadedMsg{stale: true}
+		}
+		return usageLoadedMsg{data: data, stale: stale}
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,7 @@ main.go
 | `internal/demo`      | Synthetic demo data generator + `DataProvider` implementation   |
 | `internal/provider`  | Live `DataProvider` implementation (reads `~/.claude/`)         |
 | `internal/parallel`  | Generic `Map[T,R]` concurrent helper (errgroup-backed)          |
+| `internal/usage`     | OAuth token reader, HTTP usage client (60s TTL cache + stale fallback), progress bar renderer |
 
 ## DataProvider Interface
 
@@ -87,6 +88,7 @@ memories → memory-detail  (requires project context)
 - [[demo-package]] — synthetic demo data generator and DataProvider
 - [[provider-package]] — live DataProvider implementation
 - [[parallel-package]] — generic concurrent map helper
+- [[usage-package]] — OAuth usage monitoring and progress bar renderer
 - [[streaming-dedup-convention]] — JSONL streaming dedup convention for the transcript parser
 - [[test-suite]] — test coverage
 - [[ui-spec]] — UI behavior specification

--- a/docs/cmd-package.md
+++ b/docs/cmd-package.md
@@ -42,6 +42,12 @@ type rootModel struct {
     // Cached chat items for the chat table
     chatItems []ui.ChatItem
 
+    // Usage monitoring
+    usageClient *usage.Client
+    usageData   *usage.Data
+    usageStale  bool
+    usageTick   int
+
     // Static info (set once at startup)
     userStr       string
     claudeVersion string
@@ -56,6 +62,8 @@ type rootModel struct {
     historyToolCallID string // ToolCall.ID of selected sub-row; "" = cursor on parent
 }
 ```
+
+`newRootModel()` reads the OAuth token from `~/.claude/.credentials.json`, creates a `usage.Client`, and fires an initial `Fetch`; in `--demo` mode it calls `demo.GenerateUsage()` directly. `loadUsageAsync()` fires an async fetch and sends a `usageLoadedMsg{data, stale}` back into the update loop. The `TickMsg` handler increments `usageTick` and triggers `loadUsageAsync()` every 60 ticks. `syncView()` calls `usage.RenderBar(rm.usageData, rm.usageStale, w)` and assigns the result to `app.Info.UsageLine` before `updateInfo()`.
 
 On `Init`, it fires `loadData()` synchronously, then async reloads via `loadDataAsync()` which sends a `dataLoadedMsg` back into the update loop. This keeps the initial render fast while data refreshes in the background.
 
@@ -94,3 +102,4 @@ Both implement `ui.DataProvider` and live in their own packages:
 - [[parallel-package]] — used in `loadDataAsync` for concurrent turn loading
 - [[transcript-package]] — `ScanSubagents` used directly in `loadDataAsync`
 - [[config-package]] — `ClaudeDir()` used in `run()`
+- [[usage-package]] — usage client wired into rootModel; `UsageLine` injected into `app.Info`

--- a/docs/demo-package.md
+++ b/docs/demo-package.md
@@ -21,6 +21,7 @@ Generates synthetic data for `--demo` mode. Allows claudeview to be run and demo
 - `GenerateProjects() []*model.Project` — returns a fixed set of synthetic projects with sessions and agents
 - `GeneratePlugins() []*model.Plugin` — returns synthetic plugin entries
 - `GenerateMemories() []*model.Memory` — returns synthetic memory entries
+- `GenerateUsage() *usage.Data` — returns synthetic usage data for `--demo` mode (5h: 8%, resets in ~4h9m; 7d: 68%, resets in ~1d2h). Called by `cmd/root.go` to set initial `usageData`, bypassing the HTTP fetch.
 
 ## Usage
 
@@ -35,3 +36,4 @@ This package has no test files. Its correctness is validated visually via `make 
 - [[cmd-package]] — calls `demo.NewProvider()` to wire the demo `DataProvider`
 - [[model-package]] — returns types from `internal/model`
 - [[architecture]] — demo package role in the data flow
+- [[usage-package]] — `GenerateUsage()` provides synthetic `*usage.Data` for demo mode

--- a/docs/lipgloss-bg-convention.md
+++ b/docs/lipgloss-bg-convention.md
@@ -1,0 +1,38 @@
+---
+title: "lipgloss Background Layering Convention"
+type: convention
+tags: [ui, convention, lipgloss]
+---
+
+# lipgloss Background Layering Convention
+
+When rendering a row where all characters should share a background color, every nested `lipgloss.Render()` call must explicitly include `Background(colorBg)`. The outer `bgStyle.Width(N).Render(content)` alone is insufficient.
+
+## Why
+
+Each inner `style.Render(s)` emits `\x1b[0m` (reset) at its end. This reset clears any background set by the outer wrapper for all subsequent characters until the next explicit background escape. Result: literal strings and padding between styled segments render on the terminal's default background.
+
+## Rule
+
+```go
+// WRONG — literal parts lose background after inner Render() resets
+barStyle := lipgloss.NewStyle().Foreground(fg)
+content := barStyle.Render(label) + " [" + bar + "] " + barStyle.Render(pct)
+return bgStyle.Width(width).Render(content)   // gaps have no bg
+
+// CORRECT — every segment explicitly carries the background
+barStyle   := lipgloss.NewStyle().Foreground(fg).Background(colorBg)
+emptyStyle := lipgloss.NewStyle().Foreground(colorEmpty).Background(colorBg)
+bgStyle    := lipgloss.NewStyle().Background(colorBg)
+content := barStyle.Render(label) + bgStyle.Render(" [") + bar + bgStyle.Render("] ") + barStyle.Render(pct)
+return bgStyle.Width(width).Render(content)   // full row covered
+```
+
+## Applies To
+
+Any multi-segment lipgloss row that needs a uniform background (e.g., usage bar rows, styled table cells, crumb-style panels).
+
+## Related
+
+- [[ui-package]] — usage bar in `internal/usage/bar.go` uses this pattern
+- [[usage-package]] — discovered during usage bar background fix

--- a/docs/plans/2026-03-11-usage-limit-view.md
+++ b/docs/plans/2026-03-11-usage-limit-view.md
@@ -1,0 +1,1050 @@
+# Usage Limit Bar Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a persistent 2-line usage panel at the very top of every view showing filled progress bars for the 5-hour and 7-day Claude Max windows with reset countdowns. Fetched from Anthropic's internal OAuth usage API, refreshed every 60 seconds. Panel is hidden when no credentials file exists.
+
+**Architecture:** New `internal/usage/` package handles credential reading and HTTP fetch with 60s cache. `RenderBar(data, stale, width)` returns a 2-line string (one row per window) with `█░` progress bars, percentage, and "reset in Xh Xm" labels. Stored in `InfoModel.UsageLine`; `InfoModel.Height()` counts newlines in `UsageLine` to grow by the right number of lines. `rootModel` owns the `*usage.Client`, refreshes on a 60-tick interval, and sets `app.Info.UsageLine` in `syncView`.
+
+**Tech Stack:** Go standard `net/http`, lipgloss for styling, Bubble Tea async cmd pattern.
+
+**Rendered output (2 lines, terminal-width bars):**
+```
+5h [████░░░░░░░░░░░░░░░░░░░░░░░░░░]  8%   reset in 4h 9m
+7d [████████████████████░░░░░░░░░░] 68%   reset in 1d 2h
+```
+Color thresholds: >95% red (bold), >80% yellow (bold), otherwise green.
+
+---
+
+## Key File Map
+
+| File | Role |
+|------|------|
+| `internal/usage/credentials.go` | Read OAuth token from `~/.claude/.credentials.json` |
+| `internal/usage/client.go` | HTTP client, `Window`/`Data` types, 60s in-memory cache |
+| `internal/usage/bar.go` | `RenderBar(data, stale, width) string` — 2-line progress bar output |
+| `internal/usage/credentials_test.go` | Token reading tests |
+| `internal/usage/client_test.go` | httptest-based fetch + cache tests |
+| `internal/usage/bar_test.go` | Bar rendering tests |
+| `internal/ui/header.go` | Add `UsageLine string` to `InfoModel`; update `Height()` and `ViewWithMenu()` |
+| `internal/ui/header_test.go` | Tests for usage line rendering in header |
+| `cmd/root.go` | Add `usageClient`, `usageData`, async refresh, set `UsageLine` in `syncView` |
+
+> **No new ResourceType, no new view, no 'u' key.** The bar is always present at the top.
+
+---
+
+### Task 1: `internal/usage/credentials.go`
+
+**Files:**
+- Create: `internal/usage/credentials.go`
+- Create: `internal/usage/credentials_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/usage/credentials_test.go
+package usage_test
+
+import (
+    "encoding/json"
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/Curt-Park/claudeview/internal/usage"
+)
+
+func TestReadToken(t *testing.T) {
+    dir := t.TempDir()
+    creds := map[string]any{
+        "claudeAiOauth": map[string]any{
+            "accessToken": "test-token-abc",
+        },
+    }
+    data, _ := json.Marshal(creds)
+    path := filepath.Join(dir, ".credentials.json")
+    os.WriteFile(path, data, 0600)
+
+    token, err := usage.ReadToken(path)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if token != "test-token-abc" {
+        t.Errorf("got %q, want %q", token, "test-token-abc")
+    }
+}
+
+func TestReadTokenMissingFile(t *testing.T) {
+    _, err := usage.ReadToken("/nonexistent/.credentials.json")
+    if err == nil {
+        t.Fatal("expected error for missing file")
+    }
+}
+
+func TestReadTokenEmptyToken(t *testing.T) {
+    dir := t.TempDir()
+    creds := map[string]any{"claudeAiOauth": map[string]any{"accessToken": ""}}
+    data, _ := json.Marshal(creds)
+    os.WriteFile(filepath.Join(dir, ".credentials.json"), data, 0600)
+
+    _, err := usage.ReadToken(filepath.Join(dir, ".credentials.json"))
+    if err == nil {
+        t.Fatal("expected error for empty token")
+    }
+}
+```
+
+**Step 2: Run tests to confirm they fail**
+
+```
+go test ./internal/usage/... -run TestReadToken -v
+```
+Expected: compile error — package does not exist yet.
+
+**Step 3: Implement**
+
+```go
+// internal/usage/credentials.go
+package usage
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+)
+
+type credentials struct {
+    ClaudeAiOauth struct {
+        AccessToken string `json:"accessToken"`
+    } `json:"claudeAiOauth"`
+}
+
+// ReadToken reads the OAuth access token from the given credentials file path.
+// Returns an error if the file is missing, malformed, or the token is empty.
+func ReadToken(path string) (string, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return "", fmt.Errorf("reading credentials: %w", err)
+    }
+    var creds credentials
+    if err := json.Unmarshal(data, &creds); err != nil {
+        return "", fmt.Errorf("parsing credentials: %w", err)
+    }
+    if creds.ClaudeAiOauth.AccessToken == "" {
+        return "", fmt.Errorf("no accessToken in credentials")
+    }
+    return creds.ClaudeAiOauth.AccessToken, nil
+}
+```
+
+**Step 4: Run tests to confirm they pass**
+
+```
+go test ./internal/usage/... -run TestReadToken -v
+```
+Expected: PASS (3 tests).
+
+**Step 5: Commit**
+
+```bash
+git add internal/usage/credentials.go internal/usage/credentials_test.go
+git commit -m "feat(usage): add credentials reader for OAuth token"
+```
+
+---
+
+### Task 2: `internal/usage/client.go`
+
+**Files:**
+- Create: `internal/usage/client.go`
+- Create: `internal/usage/client_test.go`
+
+**Step 1: Write the failing tests**
+
+```go
+// internal/usage/client_test.go
+package usage_test
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+
+    "github.com/Curt-Park/claudeview/internal/usage"
+)
+
+func makeServer(t *testing.T, fiveHourPct, sevenDayPct float64) *httptest.Server {
+    t.Helper()
+    return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        payload := map[string]any{
+            "five_hour": map[string]any{
+                "utilization": fiveHourPct,
+                "resets_at":   time.Now().Add(2 * time.Hour).Format(time.RFC3339Nano),
+            },
+            "seven_day": map[string]any{
+                "utilization": sevenDayPct,
+                "resets_at":   time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339Nano),
+            },
+        }
+        w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(payload)
+    }))
+}
+
+func TestClientFetch(t *testing.T) {
+    srv := makeServer(t, 42.5, 18.0)
+    defer srv.Close()
+
+    c := usage.NewClient("test-token", srv.URL)
+    data, stale, err := c.Fetch(t.Context())
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if stale {
+        t.Error("expected fresh result on first fetch")
+    }
+    if data.FiveHour == nil || data.FiveHour.Utilization != 42.5 {
+        t.Errorf("unexpected FiveHour: %v", data.FiveHour)
+    }
+    if data.SevenDay == nil || data.SevenDay.Utilization != 18.0 {
+        t.Errorf("unexpected SevenDay: %v", data.SevenDay)
+    }
+}
+
+func TestClientFetchCaches(t *testing.T) {
+    calls := 0
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        calls++
+        payload := map[string]any{
+            "five_hour": map[string]any{"utilization": 10.0, "resets_at": time.Now().Add(time.Hour).Format(time.RFC3339Nano)},
+            "seven_day": map[string]any{"utilization": 5.0, "resets_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339Nano)},
+        }
+        json.NewEncoder(w).Encode(payload)
+    }))
+    defer srv.Close()
+
+    c := usage.NewClient("tok", srv.URL)
+    c.Fetch(t.Context())
+    c.Fetch(t.Context()) // should hit cache, not server
+
+    if calls != 1 {
+        t.Errorf("expected 1 HTTP call, got %d (caching not working)", calls)
+    }
+}
+
+func TestClientFetchHTTPError(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        http.Error(w, "internal server error", http.StatusInternalServerError)
+    }))
+    defer srv.Close()
+
+    c := usage.NewClient("tok", srv.URL)
+    _, _, err := c.Fetch(t.Context())
+    if err == nil {
+        t.Fatal("expected error for HTTP 500")
+    }
+}
+
+func TestClientFetchStaleOnError(t *testing.T) {
+    // First call succeeds, second call fails → should return stale data.
+    callCount := 0
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        callCount++
+        if callCount == 1 {
+            payload := map[string]any{
+                "five_hour": map[string]any{"utilization": 50.0, "resets_at": time.Now().Add(time.Hour).Format(time.RFC3339Nano)},
+                "seven_day": map[string]any{"utilization": 25.0, "resets_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339Nano)},
+            }
+            json.NewEncoder(w).Encode(payload)
+        } else {
+            http.Error(w, "error", http.StatusInternalServerError)
+        }
+    }))
+    defer srv.Close()
+
+    c := usage.NewClient("tok", srv.URL)
+    // Force TTL to 0 so second call isn't cached.
+    c.SetTTL(0)
+    c.Fetch(t.Context())
+    data, stale, err := c.Fetch(t.Context())
+    if err != nil {
+        t.Fatalf("expected stale fallback, got error: %v", err)
+    }
+    if !stale {
+        t.Error("expected stale=true on second failing fetch")
+    }
+    if data == nil || data.FiveHour == nil {
+        t.Error("expected stale data to be non-nil")
+    }
+}
+```
+
+**Step 2: Run tests to confirm they fail**
+
+```
+go test ./internal/usage/... -run TestClient -v
+```
+Expected: compile error — `usage.NewClient` not defined.
+
+**Step 3: Implement**
+
+```go
+// internal/usage/client.go
+package usage
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "sync"
+    "time"
+)
+
+const (
+    defaultBaseURL = "https://api.anthropic.com"
+    usagePath      = "/api/oauth/usage"
+    defaultTTL     = 60 * time.Second
+    requestTimeout = 5 * time.Second
+    betaHeader     = "oauth-2025-04-20"
+)
+
+// Window holds utilization data for one rate-limit window.
+type Window struct {
+    Utilization float64    // 0-100 percentage
+    ResetsAt    *time.Time // nil if not parseable
+}
+
+// Data holds the full API response.
+type Data struct {
+    FiveHour     *Window
+    SevenDay     *Window
+    SevenDayOpus *Window // nil for non-Opus tiers
+}
+
+// Client fetches and caches usage data from the Anthropic OAuth usage API.
+type Client struct {
+    token   string
+    baseURL string
+    ttl     time.Duration
+
+    mu       sync.Mutex
+    cached   *Data
+    cachedAt time.Time
+    lastGood *Data // last successful response, for stale fallback
+}
+
+// NewClient creates a new usage client.
+// baseURL is optional; leave empty for the real Anthropic API.
+// Tests pass a local httptest server URL.
+func NewClient(token, baseURL string) *Client {
+    if baseURL == "" {
+        baseURL = defaultBaseURL
+    }
+    return &Client{token: token, baseURL: baseURL, ttl: defaultTTL}
+}
+
+// SetTTL overrides the cache TTL (used in tests to bypass caching).
+func (c *Client) SetTTL(d time.Duration) { c.ttl = d }
+
+// Fetch returns usage data, using cache if fresh.
+// stale=true means a previously successful response is returned due to a fetch error.
+func (c *Client) Fetch(ctx context.Context) (*Data, bool, error) {
+    c.mu.Lock()
+    if c.cached != nil && time.Since(c.cachedAt) < c.ttl {
+        cached := c.cached
+        c.mu.Unlock()
+        return cached, false, nil
+    }
+    c.mu.Unlock()
+
+    ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+    defer cancel()
+
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+usagePath, nil)
+    if err != nil {
+        return c.stale(fmt.Errorf("building request: %w", err))
+    }
+    req.Header.Set("Authorization", "Bearer "+c.token)
+    req.Header.Set("anthropic-beta", betaHeader)
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return c.stale(fmt.Errorf("fetching usage: %w", err))
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return c.stale(fmt.Errorf("usage API returned HTTP %d", resp.StatusCode))
+    }
+
+    var raw struct {
+        FiveHour     *rawWindow `json:"five_hour"`
+        SevenDay     *rawWindow `json:"seven_day"`
+        SevenDayOpus *rawWindow `json:"seven_day_opus"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+        return c.stale(fmt.Errorf("decoding response: %w", err))
+    }
+
+    data := &Data{
+        FiveHour:     parseWindow(raw.FiveHour),
+        SevenDay:     parseWindow(raw.SevenDay),
+        SevenDayOpus: parseWindow(raw.SevenDayOpus),
+    }
+
+    c.mu.Lock()
+    c.cached = data
+    c.cachedAt = time.Now()
+    c.lastGood = data
+    c.mu.Unlock()
+
+    return data, false, nil
+}
+
+type rawWindow struct {
+    Utilization float64 `json:"utilization"`
+    ResetsAtRaw *string `json:"resets_at"`
+}
+
+func parseWindow(r *rawWindow) *Window {
+    if r == nil {
+        return nil
+    }
+    w := &Window{Utilization: r.Utilization}
+    if r.ResetsAtRaw != nil {
+        if t, err := time.Parse(time.RFC3339Nano, *r.ResetsAtRaw); err == nil {
+            w.ResetsAt = &t
+        }
+    }
+    return w
+}
+
+// stale returns the last successful response (stale=true) or an error if none.
+func (c *Client) stale(err error) (*Data, bool, error) {
+    c.mu.Lock()
+    last := c.lastGood
+    c.mu.Unlock()
+    if last != nil {
+        return last, true, nil
+    }
+    return nil, false, err
+}
+```
+
+**Step 4: Run tests to confirm they pass**
+
+```
+go test ./internal/usage/... -run TestClient -v
+```
+Expected: PASS (4 tests).
+
+**Step 5: Commit**
+
+```bash
+git add internal/usage/client.go internal/usage/client_test.go
+git commit -m "feat(usage): add HTTP client with 60s caching and stale fallback"
+```
+
+---
+
+### Task 3: `internal/usage/bar.go` — progress bar renderer
+
+**Files:**
+- Create: `internal/usage/bar.go`
+- Create: `internal/usage/bar_test.go`
+
+**Output format** (2 lines, scales with terminal width):
+```
+5h [████░░░░░░░░░░░░░░░░░░░░░░░░░░]  8%   reset in 4h 9m
+7d [████████████████████░░░░░░░░░░] 68%   reset in 1d 2h
+```
+
+Color thresholds: >95% red bold, >80% yellow bold, otherwise green.
+`width` parameter controls how wide the `█░` bar segment is.
+
+**Step 1: Write the failing tests**
+
+```go
+// internal/usage/bar_test.go
+package usage_test
+
+import (
+    "strings"
+    "testing"
+    "time"
+
+    "github.com/Curt-Park/claudeview/internal/usage"
+)
+
+func TestRenderBar_Normal(t *testing.T) {
+    resetsAt := time.Now().Add(4*time.Hour + 9*time.Minute)
+    data := &usage.Data{
+        FiveHour: &usage.Window{Utilization: 8.0, ResetsAt: &resetsAt},
+        SevenDay: &usage.Window{Utilization: 68.0, ResetsAt: &resetsAt},
+    }
+    out := usage.RenderBar(data, false, 80)
+    lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+    if len(lines) != 2 {
+        t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+    }
+    if !strings.Contains(out, "5h") {
+        t.Error("expected '5h' label")
+    }
+    if !strings.Contains(out, "7d") {
+        t.Error("expected '7d' label")
+    }
+    if !strings.Contains(out, "reset in") {
+        t.Error("expected 'reset in' countdown label")
+    }
+}
+
+func TestRenderBar_NilData(t *testing.T) {
+    out := usage.RenderBar(nil, false, 80)
+    if out != "" {
+        t.Errorf("expected empty string for nil data, got %q", out)
+    }
+}
+
+func TestRenderBar_NoResetTime(t *testing.T) {
+    data := &usage.Data{
+        FiveHour: &usage.Window{Utilization: 50.0, ResetsAt: nil},
+        SevenDay: &usage.Window{Utilization: 20.0, ResetsAt: nil},
+    }
+    out := usage.RenderBar(data, false, 80)
+    if !strings.Contains(out, "5h") {
+        t.Error("expected '5h' label even without reset time")
+    }
+    // No crash; reset in label omitted when ResetsAt is nil
+    if strings.Contains(out, "reset in") {
+        t.Error("should not show 'reset in' when ResetsAt is nil")
+    }
+}
+
+func TestRenderBar_Stale(t *testing.T) {
+    resetsAt := time.Now().Add(time.Hour)
+    data := &usage.Data{
+        FiveHour: &usage.Window{Utilization: 30.0, ResetsAt: &resetsAt},
+        SevenDay: &usage.Window{Utilization: 10.0, ResetsAt: &resetsAt},
+    }
+    out := usage.RenderBar(data, true, 80)
+    if !strings.Contains(out, "5h") {
+        t.Error("expected bar to render even when stale")
+    }
+}
+
+func TestRenderBar_ProgressFilled(t *testing.T) {
+    resetsAt := time.Now().Add(time.Hour)
+    data := &usage.Data{
+        FiveHour: &usage.Window{Utilization: 100.0, ResetsAt: &resetsAt},
+        SevenDay: &usage.Window{Utilization: 0.0, ResetsAt: &resetsAt},
+    }
+    out := usage.RenderBar(data, false, 80)
+    // 100% should have no empty cells, 0% should have no filled cells
+    lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+    if len(lines) != 2 {
+        t.Fatalf("expected 2 lines, got %d", len(lines))
+    }
+}
+
+func TestRenderBar_WithOpus(t *testing.T) {
+    resetsAt := time.Now().Add(time.Hour)
+    data := &usage.Data{
+        FiveHour:     &usage.Window{Utilization: 10.0, ResetsAt: &resetsAt},
+        SevenDay:     &usage.Window{Utilization: 20.0, ResetsAt: &resetsAt},
+        SevenDayOpus: &usage.Window{Utilization: 5.0, ResetsAt: &resetsAt},
+    }
+    out := usage.RenderBar(data, false, 80)
+    lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+    if len(lines) != 3 {
+        t.Fatalf("expected 3 lines (5h + 7d + opus), got %d", len(lines))
+    }
+}
+```
+
+**Step 2: Run tests to confirm they fail**
+
+```
+go test ./internal/usage/... -run TestRenderBar -v
+```
+Expected: compile error — `usage.RenderBar` not defined.
+
+**Step 3: Implement**
+
+```go
+// internal/usage/bar.go
+package usage
+
+import (
+    "fmt"
+    "strings"
+    "time"
+
+    "github.com/charmbracelet/lipgloss"
+)
+
+var (
+    colorNormal   = lipgloss.Color("82")  // green
+    colorWarning  = lipgloss.Color("214") // yellow
+    colorCritical = lipgloss.Color("196") // red
+    colorEmpty    = lipgloss.Color("238") // dark gray for empty bar cells
+    colorDim      = lipgloss.Color("243") // gray for stale
+)
+
+// RenderBar renders a 2-line (or 3-line if SevenDayOpus is set) progress bar panel:
+//
+//	5h [████░░░░░░░░░░░░░░░░░░░░░░░░░░]  8%   reset in 4h 9m
+//	7d [████████████████████░░░░░░░░░░] 68%   reset in 1d 2h
+//
+// width is the total terminal width; the bar segment scales to fill it.
+// Returns "" if data is nil.
+func RenderBar(data *Data, stale bool, width int) string {
+    if data == nil {
+        return ""
+    }
+
+    // Label width: "opus" is widest at 4 chars.
+    const labelW = 4
+    // Right side: "100%   reset in 99d 23h" ≈ 26 chars max
+    const rightW = 28
+    // Bar segment fills the rest: [label] [bar] [right]
+    // 3 = space + "[" + "]"
+    barW := width - labelW - 3 - rightW
+    if barW < 8 {
+        barW = 8
+    }
+    if barW > 80 {
+        barW = 80
+    }
+
+    var rows []string
+    if w := data.FiveHour; w != nil {
+        rows = append(rows, renderProgressRow("5h", w, stale, labelW, barW))
+    }
+    if w := data.SevenDay; w != nil {
+        rows = append(rows, renderProgressRow("7d", w, stale, labelW, barW))
+    }
+    if w := data.SevenDayOpus; w != nil {
+        rows = append(rows, renderProgressRow("opus", w, stale, labelW, barW))
+    }
+
+    if len(rows) == 0 {
+        return ""
+    }
+    return strings.Join(rows, "\n")
+}
+
+func renderProgressRow(label string, w *Window, stale bool, labelW, barW int) string {
+    pct := w.Utilization
+    if pct < 0 {
+        pct = 0
+    }
+    if pct > 100 {
+        pct = 100
+    }
+
+    filled := int(pct / 100.0 * float64(barW))
+    empty := barW - filled
+
+    // Choose color based on utilization and stale state.
+    var fg lipgloss.Color
+    if stale {
+        fg = colorDim
+    } else if pct > 95 {
+        fg = colorCritical
+    } else if pct > 80 {
+        fg = colorWarning
+    } else {
+        fg = colorNormal
+    }
+    barStyle := lipgloss.NewStyle().Foreground(fg)
+    if !stale && pct > 80 {
+        barStyle = barStyle.Bold(true)
+    }
+    emptyStyle := lipgloss.NewStyle().Foreground(colorEmpty)
+
+    bar := barStyle.Render(strings.Repeat("█", filled)) + emptyStyle.Render(strings.Repeat("░", empty))
+
+    pctStr := fmt.Sprintf("%3.0f%%", pct)
+
+    var resetStr string
+    if w.ResetsAt != nil {
+        resetStr = "   reset in " + formatCountdown(*w.ResetsAt)
+    }
+
+    labelPad := strings.Repeat(" ", labelW-len([]rune(label)))
+    return barStyle.Render(label) + labelPad + " [" + bar + "] " + barStyle.Render(pctStr) + lipgloss.NewStyle().Foreground(colorDim).Render(resetStr)
+}
+
+// formatCountdown formats a future time as a human-readable countdown.
+func formatCountdown(t time.Time) string {
+    d := time.Until(t)
+    if d <= 0 {
+        return "soon"
+    }
+    if d < time.Minute {
+        return fmt.Sprintf("%ds", int(d.Seconds()))
+    }
+    if d < time.Hour {
+        return fmt.Sprintf("%dm", int(d.Minutes()))
+    }
+    if d < 24*time.Hour {
+        h := int(d.Hours())
+        m := int(d.Minutes()) % 60
+        if m == 0 {
+            return fmt.Sprintf("%dh", h)
+        }
+        return fmt.Sprintf("%dh %dm", h, m)
+    }
+    days := int(d.Hours()) / 24
+    h := int(d.Hours()) % 24
+    if h == 0 {
+        return fmt.Sprintf("%dd", days)
+    }
+    return fmt.Sprintf("%dd %dh", days, h)
+}
+```
+
+**Step 4: Run tests to confirm they pass**
+
+```
+go test ./internal/usage/... -run TestRenderBar -v
+```
+Expected: PASS (6 tests).
+
+**Step 5: Commit**
+
+```bash
+git add internal/usage/bar.go internal/usage/bar_test.go
+git commit -m "feat(usage): add progress bar renderer with reset countdown"
+```
+
+---
+
+### Task 4: Add `UsageLine` to `InfoModel` in `internal/ui/header.go`
+
+**Files:**
+- Modify: `internal/ui/header.go`
+- Modify: `internal/ui/header_test.go` (or create if it doesn't exist — check first)
+
+**Changes:**
+
+1. Add `UsageLine string` field to `InfoModel`.
+
+2. Update `Height()` to count actual lines in `UsageLine` (2 for 5h+7d, 3 if Opus window also present):
+```go
+func (info InfoModel) Height(navCount, actionCount, utilCount int) int {
+    base := max(5, 1+max(navCount, max(actionCount, utilCount)))
+    if info.UsageLine != "" {
+        return base + strings.Count(info.UsageLine, "\n") + 1
+    }
+    return base
+}
+```
+
+3. In `ViewWithMenu()`, prepend the usage line as the very first line when set:
+```go
+func (info InfoModel) ViewWithMenu(menu MenuModel) string {
+    // ... existing code ...
+
+    lines := []string{projectLine}
+    // ... existing loop building lines ...
+
+    result := strings.Join(lines, "\n")
+    if info.UsageLine != "" {
+        return info.UsageLine + "\n" + result
+    }
+    return result
+}
+```
+
+**Step 1: Check if header_test.go exists**
+
+```
+ls internal/ui/header_test.go 2>/dev/null || echo "missing"
+```
+
+**Step 2: Write tests** (add to existing file or create new)
+
+```go
+func TestInfoModelHeightWithUsageLine(t *testing.T) {
+    info := ui.InfoModel{}
+    base := info.Height(4, 3, 1)
+
+    info.UsageLine = "[5h: 8% 4h 9m] [7d: 68% 1d 2h]"
+    withUsage := info.Height(4, 3, 1)
+
+    if withUsage != base+1 {
+        t.Errorf("expected height %d with usage line, got %d", base+1, withUsage)
+    }
+}
+
+func TestInfoModelViewWithUsageLine(t *testing.T) {
+    info := ui.InfoModel{
+        UsageLine: "[5h: 8%] [7d: 68%]",
+        Width:     80,
+    }
+    menu := ui.MenuModel{}
+    out := info.ViewWithMenu(menu)
+    lines := strings.Split(out, "\n")
+    if lines[0] != "[5h: 8%] [7d: 68%]" {
+        t.Errorf("expected usage line as first line, got %q", lines[0])
+    }
+}
+
+func TestInfoModelViewNoUsageLine(t *testing.T) {
+    info := ui.InfoModel{Width: 80}
+    menu := ui.MenuModel{}
+    out := info.ViewWithMenu(menu)
+    // First line should be the Project line, not an empty usage line
+    if strings.HasPrefix(out, "\n") {
+        t.Error("should not start with newline when UsageLine is empty")
+    }
+}
+```
+
+**Step 3: Run tests to confirm they fail**
+
+```
+go test ./internal/ui/... -run TestInfoModel -v
+```
+Expected: FAIL — `UsageLine` field not yet added.
+
+**Step 4: Make the changes** to `internal/ui/header.go` as described above.
+
+**Step 5: Run tests to confirm they pass**
+
+```
+go test ./internal/ui/... -run TestInfoModel -v
+```
+Expected: PASS
+
+**Step 6: Run full test suite to catch regressions**
+
+```
+make test
+```
+Expected: PASS
+
+**Step 7: Commit**
+
+```bash
+git add internal/ui/header.go internal/ui/header_test.go
+git commit -m "feat(usage): add UsageLine field to InfoModel for usage bar display"
+```
+
+---
+
+### Task 5: Wire usage client into `cmd/root.go`
+
+**Files:**
+- Modify: `cmd/root.go`
+
+**Step 1: Add fields to `rootModel`**
+
+```go
+type rootModel struct {
+    // ... existing fields ...
+
+    // Usage bar
+    usageClient *usage.Client
+    usageData   *usage.Data
+    usageStale  bool
+    usageTick   int // increments each tick; refresh at multiples of 60
+}
+```
+
+**Step 2: Initialize in `newRootModel()`**
+
+After the existing initialization block, add:
+
+```go
+// Initialize usage client if credentials are available.
+credPath := filepath.Join(config.ClaudeDir(), ".credentials.json")
+if token, err := usage.ReadToken(credPath); err == nil {
+    rm.usageClient = usage.NewClient(token, "")
+    // Trigger an immediate fetch so the bar shows on startup.
+    if data, stale, err := rm.usageClient.Fetch(context.Background()); err == nil {
+        rm.usageData = data
+        rm.usageStale = stale
+    }
+}
+```
+
+Add imports:
+```go
+"context"
+"path/filepath"
+"github.com/Curt-Park/claudeview/internal/usage"
+```
+
+**Step 3: Add `usageLoadedMsg` type**
+
+```go
+type usageLoadedMsg struct {
+    data  *usage.Data
+    stale bool
+}
+```
+
+**Step 4: Add `loadUsageAsync()` method**
+
+```go
+func (rm *rootModel) loadUsageAsync() tea.Cmd {
+    if rm.usageClient == nil {
+        return nil
+    }
+    client := rm.usageClient
+    return func() tea.Msg {
+        data, stale, err := client.Fetch(context.Background())
+        if err != nil {
+            return usageLoadedMsg{stale: true}
+        }
+        return usageLoadedMsg{data: data, stale: stale}
+    }
+}
+```
+
+**Step 5: Handle refresh in `Update()`**
+
+In the `ui.TickMsg` case:
+```go
+case ui.TickMsg:
+    rm.syncView()
+    rm.usageTick++
+    if !rm.loading {
+        rm.loading = true
+        extraCmd = rm.loadDataAsync()
+    }
+    // Refresh usage every 60 ticks (≈60 seconds).
+    if rm.usageTick%60 == 0 {
+        extraCmd = tea.Batch(extraCmd, rm.loadUsageAsync())
+    }
+```
+
+Add a case for `usageLoadedMsg` in the switch:
+```go
+case usageLoadedMsg:
+    rm.usageData = msg.data
+    rm.usageStale = msg.stale
+    rm.syncView()
+```
+
+**Step 6: Set `UsageLine` in `syncView()`**
+
+At the start of `syncView()`, add before `rm.updateInfo()`:
+```go
+// Render usage bar (empty string if no data).
+rm.app.Info.UsageLine = usage.RenderBar(rm.usageData, rm.usageStale, w)
+```
+(`w` is already computed at the top of `syncView()` as the content width.)
+
+**Step 7: Add demo usage data**
+
+In `internal/demo/generator.go`, add:
+
+```go
+// GenerateUsage returns synthetic usage data for demo mode.
+func GenerateUsage() *usage.Data {
+    resetsAt5h := time.Now().Add(4*time.Hour + 9*time.Minute)
+    resetsAt7d := time.Now().Add(24*time.Hour + 2*time.Hour)
+    return &usage.Data{
+        FiveHour: &usage.Window{Utilization: 8.0, ResetsAt: &resetsAt5h},
+        SevenDay: &usage.Window{Utilization: 68.0, ResetsAt: &resetsAt7d},
+    }
+}
+```
+
+Import `"github.com/Curt-Park/claudeview/internal/usage"` in `generator.go`.
+
+In `newRootModel()` in `cmd/root.go`, when demo mode is active:
+```go
+if demoMode {
+    rm.usageData = demo.GenerateUsage()
+    rm.app.Info.UsageLine = usage.RenderBar(rm.usageData, false, rm.app.Width)
+}
+```
+
+> **Note:** Check if there's a `demoMode` variable accessible in `newRootModel` or if it needs to be passed in. Currently `demoMode` is a package-level var in `cmd/root.go`, so it's accessible.
+
+**Step 8: Build and verify**
+
+```
+go build ./...
+```
+Expected: success.
+
+**Step 9: Run full test suite**
+
+```
+make test
+```
+Expected: PASS
+
+**Step 10: Manual smoke test**
+
+```
+# With real credentials:
+./claudeview
+# → first line should show [5h: X% Xh Xm] [7d: X% Xd Xh]
+
+# Demo mode:
+./claudeview --demo
+# → first line should show [5h: 8% 4h 9m] [7d: 68% 1d 2h]
+```
+
+**Step 11: Commit**
+
+```bash
+git add cmd/root.go internal/demo/generator.go
+git commit -m "feat(usage): wire usage client into rootModel with async refresh and usage bar"
+```
+
+---
+
+### Task 6: Pre-completion checklist
+
+**Step 1: Format**
+```
+make fmt
+```
+Fix any formatting issues, then re-stage changed files.
+
+**Step 2: Lint**
+```
+make lint
+```
+Fix any lint issues.
+
+**Step 3: Full test suite with race detector**
+```
+make test
+```
+All tests must pass.
+
+**Step 4: Commit any fixes**
+```bash
+git add -p
+git commit -m "fix(usage): address fmt/lint issues"
+```
+
+---
+
+## Summary
+
+| File | Change |
+|------|--------|
+| `internal/usage/credentials.go` | New — reads OAuth token |
+| `internal/usage/credentials_test.go` | New — 3 tests |
+| `internal/usage/client.go` | New — HTTP client with 60s cache + stale fallback |
+| `internal/usage/client_test.go` | New — 4 tests using httptest |
+| `internal/usage/bar.go` | New — compact bracket renderer + countdown formatter |
+| `internal/usage/bar_test.go` | New — 5 tests |
+| `internal/ui/header.go` | Add `UsageLine string` to `InfoModel`, update `Height()` and `ViewWithMenu()` |
+| `internal/ui/header_test.go` | Add 3 tests for usage line behavior |
+| `cmd/root.go` | Add client init, async refresh, `usageLoadedMsg`, `syncView` wiring |
+| `internal/demo/generator.go` | Add `GenerateUsage()` with demo values |

--- a/docs/test-suite.md
+++ b/docs/test-suite.md
@@ -19,6 +19,7 @@ Tests span five packages. `internal/ui` has the largest test surface (integratio
 | `filter_test.go`        | `FilterModel` unit tests                                    |
 | `crumbs_test.go`        | `CrumbsModel` unit tests                                    |
 | `menu_test.go`          | `MenuModel` and nav hint unit tests                         |
+| `header_test.go`        | `InfoModel.Height()` with multi-line usage, `ViewWithMenu()` usage-first output, no leading newline when empty |
 | `testhelpers_test.go`   | Shared helpers: `mockDP`, key senders, row builders         |
 
 ## Other Test Packages
@@ -29,6 +30,7 @@ Tests span five packages. `internal/ui` has the largest test surface (integratio
 | `internal/config`      | `settings_test.go`, `plugins_test.go`        | ~15   |
 | `internal/model`       | `agent_test.go`, `session_test.go`, `project_test.go`, `tool_call_test.go`, `plugin_test.go`, `resource_test.go`, `turn_test.go`, `slug_group_test.go` | ~52 |
 | `internal/transcript`  | `scanner_test.go`, `parser_test.go` (includes slug extraction tests and streaming dedup coverage: `TestStreamingDeduplicationInParse`, `TestMergeConsecutiveSameRequestID`, `TestStreamingDeduplicationInAggregates`, `TestStreamingDeduplicationInFileIncremental`) | ~17 |
+| `internal/usage`       | `credentials_test.go`, `client_test.go`, `bar_test.go` | ~15 |
 
 ## Pattern
 

--- a/docs/ui-package.md
+++ b/docs/ui-package.md
@@ -15,7 +15,8 @@ Implements the Bubble Tea application model and all reusable chrome components.
 | `app.go`              | `AppModel` — root Bubble Tea model; key events, layout, mode   |
 | `table_view.go`       | `TableView` — scrollable table with filter, selection          |
 | `detail_render.go`    | `RenderPluginItemDetail`, `RenderMemoryDetail`, `RenderChatItemDetail`, `RenderToolCallDetail`, `ChatItemKey` — string renderers and helpers; `renderExpandedToolCall` (two-line tool call layout: name/model/duration/tokens + input + result), `renderTurnBoundary` (lightweight `── model  time  tok ──` separator between ExtraTurns) |
-| `header.go`           | Info panel (5-column layout: info, nav, util, shortcuts, quit) |
+| `header.go`           | Info panel; optional usage bar prepended above (via `UsageLine`); 5-column info layout |
+| `header_test.go`      | 3 tests: `Height()` with multi-line usage, `ViewWithMenu()` usage-first output, no leading newline when empty |
 | `menu.go`             | `MenuModel` — nav/util item lists and key highlight state      |
 | `crumbs.go`           | `CrumbsModel` — breadcrumb trail                               |
 | `flash.go`            | `FlashModel` — ephemeral status/error message                  |
@@ -31,6 +32,7 @@ Implements the Bubble Tea application model and all reusable chrome components.
 - `Resource` — current `model.ResourceType`
 - `Table` — active `TableView`
 - `Info`, `Menu`, `Crumbs`, `Flash`, `Filter` — chrome components
+- `Info.UsageLine string` — pre-rendered usage bar string (empty = hidden); `Height()` adds `strings.Count(UsageLine, "\n") + 1` when non-empty
 - `Width`, `Height` — terminal dimensions
 - `SelectedProjectHash`, `SelectedSessionID`, `SelectedSessionSlug` — drill-down context
 - `SelectedPlugin`, `SelectedPluginItem`, `SelectedMemory` — detail view context
@@ -124,3 +126,5 @@ In addition to base, status, and layout styles, `styles.go` defines:
 - [[model-package]] — `ResourceType` constants and data types
 - [[test-suite]] — AppModel integration tests
 - [[stringutil-package]] — `ExtractXMLTag` used in `cleanTextPreview`
+- [[usage-package]] — provides `UsageLine` string rendered above the info panel
+- [[lipgloss-bg-convention]] — background layering rule for multi-segment rows

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -16,6 +16,10 @@ claudeview is a k9s-style terminal dashboard for Claude Code sessions. The UI co
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
+│ USAGE BAR (0–3 rows, hidden when no credentials)                            │
+│  5h [████░░░░░░░░] 31%   reset in 2h 12m                                   │
+│  7d [████████░░░░] 38%   reset in 1d 17h                                   │
+├─────────────────────────────────────────────────────────────────────────────┤
 │ INFO PANEL (5 rows min)                                                      │
 │  col0: info   │  col1: nav cmds   │  col2: util cmds  │  col3: shortcuts    │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -32,7 +36,7 @@ claudeview is a k9s-style terminal dashboard for Claude Code sessions. The UI co
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Chrome rows**: 5+ (info) + 1 (title) + 1 (crumbs) + 1 (status) = **8+ rows**
+**Chrome rows**: 0–3 (usage) + 5+ (info) + 1 (title) + 1 (crumbs) + 1 (status) = **8+ rows**
 **Content height**: `terminal_height - chrome` (min 5), computed dynamically
 
 ---
@@ -56,7 +60,7 @@ claudeview:   <value>   <enter> (context)
 - **Col 3**: p/m jump shortcuts (context-sensitive)
 - **Col 4**: `ctrl+c quit` (first row only)
 
-Panel height: `max(5, 1 + max(navCount, utilCount))`
+Panel height: `base = max(5, 1+max(navCount, actionCount, utilCount))`; when `UsageLine != ""`: `base + strings.Count(UsageLine, "\n") + 1`
 
 ### Context-Dependent Values
 

--- a/docs/usage-package.md
+++ b/docs/usage-package.md
@@ -1,0 +1,92 @@
+---
+title: "Usage Package (internal/usage)"
+type: component
+tags: [usage, internals, api]
+---
+
+# Usage Package — `internal/usage`
+
+Monitors Claude Max subscription utilization via Anthropic's internal OAuth API. Provides token reading, a caching HTTP client, and a progress bar renderer. Displayed as a 0–3 row panel above the info panel when credentials are available.
+
+## Files
+
+| File                    | Purpose                                                                 |
+|-------------------------|-------------------------------------------------------------------------|
+| `credentials.go`        | Reads OAuth access token from `~/.claude/.credentials.json`             |
+| `client.go`             | HTTP client with 60s TTL in-memory cache and stale-fallback on error    |
+| `bar.go`                | Renders `█░` progress bar rows with dark background (`colorBg "238"`)  |
+| `credentials_test.go`   | Tests for token reading (happy path, missing file, malformed JSON)      |
+| `client_test.go`        | Tests for cache TTL, stale fallback, error handling                     |
+| `bar_test.go`           | Tests for bar rendering (line count, 100%/0% fill assertions)           |
+
+## API
+
+Undocumented Anthropic internal endpoint:
+```
+GET https://api.anthropic.com/api/oauth/usage
+Headers: Authorization: Bearer <token>
+         anthropic-beta: oauth-2025-04-20
+```
+
+Response fields mapped to `Data`:
+```go
+type Window struct {
+    Utilization float64  // 0–100
+    ResetsAt    *time.Time
+}
+type Data struct {
+    FiveHour     *Window
+    SevenDay     *Window
+    SevenDayOpus *Window  // non-nil only for Opus-tier subscriptions
+}
+```
+
+## Credentials
+
+OAuth token read from `~/.claude/.credentials.json`:
+```json
+{ "claudeAiOauth": { "accessToken": "..." } }
+```
+`ReadToken(path string) (string, error)` — exported, path-parameterized for testing.
+
+## Client
+
+```go
+func NewClient(token, baseURL string) *Client
+func (c *Client) SetTTL(d time.Duration)          // mutex-protected; for tests
+func (c *Client) Fetch(ctx context.Context) (*Data, bool, error)
+// Returns: data, stale (true if serving cached data after error), error
+```
+
+- Cache TTL: 60 seconds (default)
+- Stale fallback: on HTTP error, returns last good data with `stale=true`
+- Thread-safe: mutex protects `ttl`, `cache`, `cachedAt`, `lastGood`
+
+## Bar Renderer
+
+```go
+func RenderBar(data *Data, stale bool, width int) string
+// Returns "" if data is nil
+```
+
+- Renders one row per non-nil Window (5h, 7d, opus)
+- Color thresholds: `>95%` critical red, `>80%` warning orange, otherwise green; stale = dim
+- Each row wrapped with `bgStyle.Width(width).Render(...)` (dark bg `"238"`, matches `StyleCrumbs`)
+- See [[lipgloss-bg-convention]] — every sub-style must explicitly set `Background(colorBg)`
+
+## Integration in rootModel
+
+`cmd/root.go` wires usage monitoring:
+- `newRootModel()` reads credentials, creates `Client`, fires initial `Fetch`
+- Demo mode: calls `demo.GenerateUsage()` to skip HTTP
+- `TickMsg` handler: increments `usageTick`, fires `loadUsageAsync()` every 60 ticks
+- `syncView()`: assigns `usage.RenderBar(rm.usageData, rm.usageStale, w)` to `app.Info.UsageLine`
+
+## Related
+
+- [[cmd-package]] — wires usage client into rootModel
+- [[ui-package]] — `InfoModel.UsageLine` consumed by `ViewWithMenu`
+- [[ui-spec]] — usage bar appears above info panel in screen layout
+- [[demo-package]] — `GenerateUsage()` provides synthetic usage for --demo
+- [[architecture]] — usage package in package table
+- [[lipgloss-bg-convention]] — background layering rule applied in `bar.go`

--- a/internal/demo/generator.go
+++ b/internal/demo/generator.go
@@ -6,7 +6,18 @@ import (
 	"time"
 
 	"github.com/Curt-Park/claudeview/internal/model"
+	"github.com/Curt-Park/claudeview/internal/usage"
 )
+
+// GenerateUsage returns synthetic usage data for demo mode.
+func GenerateUsage() *usage.Data {
+	resetsAt5h := time.Now().Add(4*time.Hour + 9*time.Minute)
+	resetsAt7d := time.Now().Add(24*time.Hour + 2*time.Hour)
+	return &usage.Data{
+		FiveHour: &usage.Window{Utilization: 8.0, ResetsAt: &resetsAt5h},
+		SevenDay: &usage.Window{Utilization: 68.0, ResetsAt: &resetsAt7d},
+	}
+}
 
 // GenerateMemories creates synthetic demo memory files.
 func GenerateMemories() []*model.Memory {

--- a/internal/ui/header.go
+++ b/internal/ui/header.go
@@ -27,7 +27,7 @@ type InfoModel struct {
 func (info InfoModel) Height(navCount, actionCount, utilCount int) int {
 	base := max(5, 1+max(navCount, max(actionCount, utilCount)))
 	if info.UsageLine != "" {
-		return base + strings.Count(info.UsageLine, "\n") + 2 // +1 for usage lines, +1 for separator
+		return base + strings.Count(info.UsageLine, "\n") + 1 // +1 for the joining newline
 	}
 	return base
 }
@@ -169,8 +169,7 @@ func (info InfoModel) ViewWithMenu(menu MenuModel) string {
 
 	result := strings.Join(lines, "\n")
 	if info.UsageLine != "" {
-		sep := lipgloss.NewStyle().Foreground(colorGray).Background(colorDimGray).Width(info.Width).Render("")
-		return info.UsageLine + "\n" + sep + "\n" + result
+		return info.UsageLine + "\n" + result
 	}
 	return result
 }

--- a/internal/ui/header.go
+++ b/internal/ui/header.go
@@ -27,7 +27,7 @@ type InfoModel struct {
 func (info InfoModel) Height(navCount, actionCount, utilCount int) int {
 	base := max(5, 1+max(navCount, max(actionCount, utilCount)))
 	if info.UsageLine != "" {
-		return base + strings.Count(info.UsageLine, "\n") + 1
+		return base + strings.Count(info.UsageLine, "\n") + 2 // +1 for usage lines, +1 for separator
 	}
 	return base
 }
@@ -169,7 +169,8 @@ func (info InfoModel) ViewWithMenu(menu MenuModel) string {
 
 	result := strings.Join(lines, "\n")
 	if info.UsageLine != "" {
-		return info.UsageLine + "\n" + result
+		sep := lipgloss.NewStyle().Foreground(colorGray).Render(strings.Repeat("─", info.Width))
+		return info.UsageLine + "\n" + sep + "\n" + result
 	}
 	return result
 }

--- a/internal/ui/header.go
+++ b/internal/ui/header.go
@@ -169,7 +169,7 @@ func (info InfoModel) ViewWithMenu(menu MenuModel) string {
 
 	result := strings.Join(lines, "\n")
 	if info.UsageLine != "" {
-		sep := lipgloss.NewStyle().Foreground(colorGray).Render(strings.Repeat("─", info.Width))
+		sep := lipgloss.NewStyle().Foreground(colorGray).Background(colorDimGray).Width(info.Width).Render("")
 		return info.UsageLine + "\n" + sep + "\n" + result
 	}
 	return result

--- a/internal/ui/header.go
+++ b/internal/ui/header.go
@@ -18,13 +18,18 @@ type InfoModel struct {
 	Width          int
 	MemoriesActive bool               // whether <m> memories jump is available
 	Resource       model.ResourceType // current active resource (hides its own jump hint)
+	UsageLine      string             // rendered usage bar (empty = hidden)
 }
 
 // Height returns the number of terminal lines rendered by ViewWithMenu.
 // navCount, actionCount, and utilCount are the number of items in each menu column.
 // Minimum is 5 (1 project row + 4 data rows); expands if more items are needed.
 func (info InfoModel) Height(navCount, actionCount, utilCount int) int {
-	return max(5, 1+max(navCount, max(actionCount, utilCount)))
+	base := max(5, 1+max(navCount, max(actionCount, utilCount)))
+	if info.UsageLine != "" {
+		return base + strings.Count(info.UsageLine, "\n") + 1
+	}
+	return base
 }
 
 // ViewWithMenu renders the info panel with a 6-column layout:
@@ -162,7 +167,11 @@ func (info InfoModel) ViewWithMenu(menu MenuModel) string {
 		lines = append(lines, leftPart+leftPadding+nav+navPad+action+actionPad+util+utilPad+right+rightPad+quit)
 	}
 
-	return strings.Join(lines, "\n")
+	result := strings.Join(lines, "\n")
+	if info.UsageLine != "" {
+		return info.UsageLine + "\n" + result
+	}
+	return result
 }
 
 // menuMaxKeyW returns the max rendered width of "<key>" across all items.

--- a/internal/ui/header_test.go
+++ b/internal/ui/header_test.go
@@ -1,0 +1,42 @@
+package ui_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Curt-Park/claudeview/internal/ui"
+)
+
+func TestInfoModelHeightWithUsageLine(t *testing.T) {
+	info := ui.InfoModel{}
+	base := info.Height(4, 3, 1)
+
+	info.UsageLine = "line1\nline2" // 2-line usage bar
+	withUsage := info.Height(4, 3, 1)
+
+	if withUsage != base+2 {
+		t.Errorf("expected height %d with 2-line usage, got %d", base+2, withUsage)
+	}
+}
+
+func TestInfoModelViewWithUsageLine(t *testing.T) {
+	info := ui.InfoModel{
+		UsageLine: "USAGE_BAR_LINE",
+		Width:     80,
+	}
+	menu := ui.MenuModel{}
+	out := info.ViewWithMenu(menu)
+	lines := strings.Split(out, "\n")
+	if lines[0] != "USAGE_BAR_LINE" {
+		t.Errorf("expected usage line as first line, got %q", lines[0])
+	}
+}
+
+func TestInfoModelViewNoUsageLine(t *testing.T) {
+	info := ui.InfoModel{Width: 80}
+	menu := ui.MenuModel{}
+	out := info.ViewWithMenu(menu)
+	if strings.HasPrefix(out, "\n") {
+		t.Error("should not start with newline when UsageLine is empty")
+	}
+}

--- a/internal/ui/header_test.go
+++ b/internal/ui/header_test.go
@@ -30,9 +30,9 @@ func TestInfoModelViewWithUsageLine(t *testing.T) {
 	if lines[0] != "USAGE_BAR_LINE" {
 		t.Errorf("expected usage line as first line, got %q", lines[0])
 	}
-	// Line 1 (index 1) should be the separator: contains only '─' chars (after stripping ANSI).
-	if !strings.Contains(lines[1], "─") {
-		t.Errorf("expected separator line after usage bar, got %q", lines[1])
+	// Line 1 (index 1) should be the separator: a background-colored blank line.
+	if len(lines) < 3 {
+		t.Errorf("expected at least 3 lines (usage + separator + info), got %d", len(lines))
 	}
 }
 

--- a/internal/ui/header_test.go
+++ b/internal/ui/header_test.go
@@ -14,8 +14,8 @@ func TestInfoModelHeightWithUsageLine(t *testing.T) {
 	info.UsageLine = "line1\nline2" // 2-line usage bar
 	withUsage := info.Height(4, 3, 1)
 
-	if withUsage != base+2 {
-		t.Errorf("expected height %d with 2-line usage, got %d", base+2, withUsage)
+	if withUsage != base+3 { // 2 usage lines + 1 separator
+		t.Errorf("expected height %d with 2-line usage + separator, got %d", base+3, withUsage)
 	}
 }
 
@@ -29,6 +29,10 @@ func TestInfoModelViewWithUsageLine(t *testing.T) {
 	lines := strings.Split(out, "\n")
 	if lines[0] != "USAGE_BAR_LINE" {
 		t.Errorf("expected usage line as first line, got %q", lines[0])
+	}
+	// Line 1 (index 1) should be the separator: contains only '─' chars (after stripping ANSI).
+	if !strings.Contains(lines[1], "─") {
+		t.Errorf("expected separator line after usage bar, got %q", lines[1])
 	}
 }
 

--- a/internal/ui/header_test.go
+++ b/internal/ui/header_test.go
@@ -14,8 +14,8 @@ func TestInfoModelHeightWithUsageLine(t *testing.T) {
 	info.UsageLine = "line1\nline2" // 2-line usage bar
 	withUsage := info.Height(4, 3, 1)
 
-	if withUsage != base+3 { // 2 usage lines + 1 separator
-		t.Errorf("expected height %d with 2-line usage + separator, got %d", base+3, withUsage)
+	if withUsage != base+2 { // 2 usage lines + 1 joining newline
+		t.Errorf("expected height %d with 2-line usage + newline, got %d", base+2, withUsage)
 	}
 }
 
@@ -30,9 +30,9 @@ func TestInfoModelViewWithUsageLine(t *testing.T) {
 	if lines[0] != "USAGE_BAR_LINE" {
 		t.Errorf("expected usage line as first line, got %q", lines[0])
 	}
-	// Line 1 (index 1) should be the separator: a background-colored blank line.
-	if len(lines) < 3 {
-		t.Errorf("expected at least 3 lines (usage + separator + info), got %d", len(lines))
+	// Line 1 (index 1) should be the first info line.
+	if len(lines) < 2 {
+		t.Errorf("expected at least 2 lines (usage + info), got %d", len(lines))
 	}
 }
 

--- a/internal/usage/bar.go
+++ b/internal/usage/bar.go
@@ -73,11 +73,11 @@ func renderProgressRow(label string, w *Window, stale bool, labelW, barW, width 
 	} else {
 		fg = colorNormal
 	}
-	barStyle := lipgloss.NewStyle().Foreground(fg)
+	barStyle := lipgloss.NewStyle().Foreground(fg).Background(colorBg)
 	if !stale && pct > 80 {
 		barStyle = barStyle.Bold(true)
 	}
-	emptyStyle := lipgloss.NewStyle().Foreground(colorEmpty)
+	emptyStyle := lipgloss.NewStyle().Foreground(colorEmpty).Background(colorBg)
 
 	bar := barStyle.Render(strings.Repeat("█", filled)) + emptyStyle.Render(strings.Repeat("░", empty))
 	pctStr := fmt.Sprintf("%3.0f%%", pct)

--- a/internal/usage/bar.go
+++ b/internal/usage/bar.go
@@ -12,8 +12,9 @@ var (
 	colorNormal   = lipgloss.Color("82")
 	colorWarning  = lipgloss.Color("214")
 	colorCritical = lipgloss.Color("196")
-	colorEmpty    = lipgloss.Color("238")
+	colorEmpty    = lipgloss.Color("240") // slightly lighter than bg so ░ cells are visible
 	colorDim      = lipgloss.Color("243")
+	colorBg       = lipgloss.Color("238") // matches StyleCrumbs background
 )
 
 // RenderBar renders a 2-line (or 3-line if SevenDayOpus is set) progress bar panel.
@@ -35,13 +36,13 @@ func RenderBar(data *Data, stale bool, width int) string {
 
 	var rows []string
 	if w := data.FiveHour; w != nil {
-		rows = append(rows, renderProgressRow("5h", w, stale, labelW, barW))
+		rows = append(rows, renderProgressRow("5h", w, stale, labelW, barW, width))
 	}
 	if w := data.SevenDay; w != nil {
-		rows = append(rows, renderProgressRow("7d", w, stale, labelW, barW))
+		rows = append(rows, renderProgressRow("7d", w, stale, labelW, barW, width))
 	}
 	if w := data.SevenDayOpus; w != nil {
-		rows = append(rows, renderProgressRow("opus", w, stale, labelW, barW))
+		rows = append(rows, renderProgressRow("opus", w, stale, labelW, barW, width))
 	}
 
 	if len(rows) == 0 {
@@ -50,7 +51,7 @@ func RenderBar(data *Data, stale bool, width int) string {
 	return strings.Join(rows, "\n")
 }
 
-func renderProgressRow(label string, w *Window, stale bool, labelW, barW int) string {
+func renderProgressRow(label string, w *Window, stale bool, labelW, barW, width int) string {
 	pct := w.Utilization
 	if pct < 0 {
 		pct = 0
@@ -87,8 +88,10 @@ func renderProgressRow(label string, w *Window, stale bool, labelW, barW int) st
 	}
 
 	labelPad := strings.Repeat(" ", labelW-lipgloss.Width(label))
-	dimStyle := lipgloss.NewStyle().Foreground(colorDim)
-	return barStyle.Render(label) + labelPad + " [" + bar + "] " + barStyle.Render(pctStr) + dimStyle.Render(resetStr)
+	dimStyle := lipgloss.NewStyle().Foreground(colorDim).Background(colorBg)
+	bgStyle := lipgloss.NewStyle().Background(colorBg)
+	content := barStyle.Render(label) + labelPad + " [" + bar + "] " + barStyle.Render(pctStr) + dimStyle.Render(resetStr)
+	return bgStyle.Width(width).Render(content)
 }
 
 func formatCountdown(t time.Time) string {

--- a/internal/usage/bar.go
+++ b/internal/usage/bar.go
@@ -86,7 +86,7 @@ func renderProgressRow(label string, w *Window, stale bool, labelW, barW int) st
 		resetStr = "   reset in " + formatCountdown(*w.ResetsAt)
 	}
 
-	labelPad := strings.Repeat(" ", labelW-len([]rune(label)))
+	labelPad := strings.Repeat(" ", labelW-lipgloss.Width(label))
 	dimStyle := lipgloss.NewStyle().Foreground(colorDim)
 	return barStyle.Render(label) + labelPad + " [" + bar + "] " + barStyle.Render(pctStr) + dimStyle.Render(resetStr)
 }

--- a/internal/usage/bar.go
+++ b/internal/usage/bar.go
@@ -1,0 +1,119 @@
+package usage
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	colorNormal   = lipgloss.Color("82")
+	colorWarning  = lipgloss.Color("214")
+	colorCritical = lipgloss.Color("196")
+	colorEmpty    = lipgloss.Color("238")
+	colorDim      = lipgloss.Color("243")
+)
+
+// RenderBar renders a 2-line (or 3-line if SevenDayOpus is set) progress bar panel.
+// Returns "" if data is nil.
+func RenderBar(data *Data, stale bool, width int) string {
+	if data == nil {
+		return ""
+	}
+
+	const labelW = 4
+	const rightW = 28
+	barW := width - labelW - 3 - rightW
+	if barW < 8 {
+		barW = 8
+	}
+	if barW > 80 {
+		barW = 80
+	}
+
+	var rows []string
+	if w := data.FiveHour; w != nil {
+		rows = append(rows, renderProgressRow("5h", w, stale, labelW, barW))
+	}
+	if w := data.SevenDay; w != nil {
+		rows = append(rows, renderProgressRow("7d", w, stale, labelW, barW))
+	}
+	if w := data.SevenDayOpus; w != nil {
+		rows = append(rows, renderProgressRow("opus", w, stale, labelW, barW))
+	}
+
+	if len(rows) == 0 {
+		return ""
+	}
+	return strings.Join(rows, "\n")
+}
+
+func renderProgressRow(label string, w *Window, stale bool, labelW, barW int) string {
+	pct := w.Utilization
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+
+	filled := int(pct / 100.0 * float64(barW))
+	empty := barW - filled
+
+	var fg lipgloss.Color
+	if stale {
+		fg = colorDim
+	} else if pct > 95 {
+		fg = colorCritical
+	} else if pct > 80 {
+		fg = colorWarning
+	} else {
+		fg = colorNormal
+	}
+	barStyle := lipgloss.NewStyle().Foreground(fg)
+	if !stale && pct > 80 {
+		barStyle = barStyle.Bold(true)
+	}
+	emptyStyle := lipgloss.NewStyle().Foreground(colorEmpty)
+
+	bar := barStyle.Render(strings.Repeat("█", filled)) + emptyStyle.Render(strings.Repeat("░", empty))
+	pctStr := fmt.Sprintf("%3.0f%%", pct)
+
+	var resetStr string
+	if w.ResetsAt != nil {
+		resetStr = "   reset in " + formatCountdown(*w.ResetsAt)
+	}
+
+	labelPad := strings.Repeat(" ", labelW-len([]rune(label)))
+	dimStyle := lipgloss.NewStyle().Foreground(colorDim)
+	return barStyle.Render(label) + labelPad + " [" + bar + "] " + barStyle.Render(pctStr) + dimStyle.Render(resetStr)
+}
+
+func formatCountdown(t time.Time) string {
+	d := time.Until(t)
+	if d <= 0 {
+		return "soon"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	h := int(d.Hours()) % 24
+	if h == 0 {
+		return fmt.Sprintf("%dd", days)
+	}
+	return fmt.Sprintf("%dd %dh", days, h)
+}

--- a/internal/usage/bar.go
+++ b/internal/usage/bar.go
@@ -90,7 +90,7 @@ func renderProgressRow(label string, w *Window, stale bool, labelW, barW, width 
 	labelPad := strings.Repeat(" ", labelW-lipgloss.Width(label))
 	dimStyle := lipgloss.NewStyle().Foreground(colorDim).Background(colorBg)
 	bgStyle := lipgloss.NewStyle().Background(colorBg)
-	content := barStyle.Render(label) + labelPad + " [" + bar + "] " + barStyle.Render(pctStr) + dimStyle.Render(resetStr)
+	content := barStyle.Render(label) + bgStyle.Render(labelPad+" [") + bar + bgStyle.Render("] ") + barStyle.Render(pctStr) + dimStyle.Render(resetStr)
 	return bgStyle.Width(width).Render(content)
 }
 

--- a/internal/usage/bar_test.go
+++ b/internal/usage/bar_test.go
@@ -1,0 +1,91 @@
+package usage_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Curt-Park/claudeview/internal/usage"
+)
+
+func TestRenderBar_Normal(t *testing.T) {
+	resetsAt := time.Now().Add(4*time.Hour + 9*time.Minute)
+	data := &usage.Data{
+		FiveHour: &usage.Window{Utilization: 8.0, ResetsAt: &resetsAt},
+		SevenDay: &usage.Window{Utilization: 68.0, ResetsAt: &resetsAt},
+	}
+	out := usage.RenderBar(data, false, 80)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(out, "5h") {
+		t.Error("expected '5h' label")
+	}
+	if !strings.Contains(out, "7d") {
+		t.Error("expected '7d' label")
+	}
+	if !strings.Contains(out, "reset in") {
+		t.Error("expected 'reset in' countdown label")
+	}
+}
+
+func TestRenderBar_NilData(t *testing.T) {
+	out := usage.RenderBar(nil, false, 80)
+	if out != "" {
+		t.Errorf("expected empty string for nil data, got %q", out)
+	}
+}
+
+func TestRenderBar_NoResetTime(t *testing.T) {
+	data := &usage.Data{
+		FiveHour: &usage.Window{Utilization: 50.0, ResetsAt: nil},
+		SevenDay: &usage.Window{Utilization: 20.0, ResetsAt: nil},
+	}
+	out := usage.RenderBar(data, false, 80)
+	if !strings.Contains(out, "5h") {
+		t.Error("expected '5h' label even without reset time")
+	}
+	if strings.Contains(out, "reset in") {
+		t.Error("should not show 'reset in' when ResetsAt is nil")
+	}
+}
+
+func TestRenderBar_Stale(t *testing.T) {
+	resetsAt := time.Now().Add(time.Hour)
+	data := &usage.Data{
+		FiveHour: &usage.Window{Utilization: 30.0, ResetsAt: &resetsAt},
+		SevenDay: &usage.Window{Utilization: 10.0, ResetsAt: &resetsAt},
+	}
+	out := usage.RenderBar(data, true, 80)
+	if !strings.Contains(out, "5h") {
+		t.Error("expected bar to render even when stale")
+	}
+}
+
+func TestRenderBar_ProgressFilled(t *testing.T) {
+	resetsAt := time.Now().Add(time.Hour)
+	data := &usage.Data{
+		FiveHour: &usage.Window{Utilization: 100.0, ResetsAt: &resetsAt},
+		SevenDay: &usage.Window{Utilization: 0.0, ResetsAt: &resetsAt},
+	}
+	out := usage.RenderBar(data, false, 80)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+}
+
+func TestRenderBar_WithOpus(t *testing.T) {
+	resetsAt := time.Now().Add(time.Hour)
+	data := &usage.Data{
+		FiveHour:     &usage.Window{Utilization: 10.0, ResetsAt: &resetsAt},
+		SevenDay:     &usage.Window{Utilization: 20.0, ResetsAt: &resetsAt},
+		SevenDayOpus: &usage.Window{Utilization: 5.0, ResetsAt: &resetsAt},
+	}
+	out := usage.RenderBar(data, false, 80)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (5h + 7d + opus), got %d", len(lines))
+	}
+}

--- a/internal/usage/bar_test.go
+++ b/internal/usage/bar_test.go
@@ -74,6 +74,14 @@ func TestRenderBar_ProgressFilled(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
+	// 100% bar: no empty cells
+	if strings.Contains(lines[0], "░") {
+		t.Error("100% bar should have no empty cells")
+	}
+	// 0% bar: no filled cells
+	if strings.Contains(lines[1], "█") {
+		t.Error("0% bar should have no filled cells")
+	}
 }
 
 func TestRenderBar_WithOpus(t *testing.T) {

--- a/internal/usage/client.go
+++ b/internal/usage/client.go
@@ -52,7 +52,11 @@ func NewClient(token, baseURL string) *Client {
 }
 
 // SetTTL overrides the cache TTL. Primarily used in tests to bypass caching.
-func (c *Client) SetTTL(d time.Duration) { c.ttl = d }
+func (c *Client) SetTTL(d time.Duration) {
+	c.mu.Lock()
+	c.ttl = d
+	c.mu.Unlock()
+}
 
 // Fetch returns the current usage data, whether the result is stale, and any
 // error. Results are cached for the configured TTL (default 60s). On HTTP or

--- a/internal/usage/client.go
+++ b/internal/usage/client.go
@@ -85,7 +85,7 @@ func (c *Client) Fetch(ctx context.Context) (*Data, bool, error) {
 	if err != nil {
 		return c.stale(fmt.Errorf("fetching usage: %w", err))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return c.stale(fmt.Errorf("usage API returned HTTP %d", resp.StatusCode))

--- a/internal/usage/client.go
+++ b/internal/usage/client.go
@@ -1,0 +1,140 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://api.anthropic.com"
+	usagePath      = "/api/oauth/usage"
+	defaultTTL     = 60 * time.Second
+	requestTimeout = 5 * time.Second
+	betaHeader     = "oauth-2025-04-20"
+)
+
+// Window holds a single usage window's utilization percentage and reset time.
+type Window struct {
+	Utilization float64    // 0-100 percentage
+	ResetsAt    *time.Time // nil if not parseable
+}
+
+// Data holds the three usage windows returned by the Anthropic usage API.
+type Data struct {
+	FiveHour     *Window
+	SevenDay     *Window
+	SevenDayOpus *Window // nil for non-Opus tiers
+}
+
+// Client fetches usage data from the Anthropic API with in-memory caching.
+type Client struct {
+	token   string
+	baseURL string
+	ttl     time.Duration
+
+	mu       sync.Mutex
+	cached   *Data
+	cachedAt time.Time
+	lastGood *Data
+}
+
+// NewClient creates a new Client. If baseURL is empty, the production
+// Anthropic API base URL is used. Tests may pass a local httptest URL.
+func NewClient(token, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{token: token, baseURL: baseURL, ttl: defaultTTL}
+}
+
+// SetTTL overrides the cache TTL. Primarily used in tests to bypass caching.
+func (c *Client) SetTTL(d time.Duration) { c.ttl = d }
+
+// Fetch returns the current usage data, whether the result is stale, and any
+// error. Results are cached for the configured TTL (default 60s). On HTTP or
+// parse errors, the last successful response is returned with stale=true; if
+// there is no previous good response, the error is returned instead.
+func (c *Client) Fetch(ctx context.Context) (*Data, bool, error) {
+	c.mu.Lock()
+	if c.cached != nil && time.Since(c.cachedAt) < c.ttl {
+		cached := c.cached
+		c.mu.Unlock()
+		return cached, false, nil
+	}
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+usagePath, nil)
+	if err != nil {
+		return c.stale(fmt.Errorf("building request: %w", err))
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("anthropic-beta", betaHeader)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return c.stale(fmt.Errorf("fetching usage: %w", err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.stale(fmt.Errorf("usage API returned HTTP %d", resp.StatusCode))
+	}
+
+	var raw struct {
+		FiveHour     *rawWindow `json:"five_hour"`
+		SevenDay     *rawWindow `json:"seven_day"`
+		SevenDayOpus *rawWindow `json:"seven_day_opus"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return c.stale(fmt.Errorf("decoding response: %w", err))
+	}
+
+	data := &Data{
+		FiveHour:     parseWindow(raw.FiveHour),
+		SevenDay:     parseWindow(raw.SevenDay),
+		SevenDayOpus: parseWindow(raw.SevenDayOpus),
+	}
+
+	c.mu.Lock()
+	c.cached = data
+	c.cachedAt = time.Now()
+	c.lastGood = data
+	c.mu.Unlock()
+
+	return data, false, nil
+}
+
+type rawWindow struct {
+	Utilization float64 `json:"utilization"`
+	ResetsAtRaw *string `json:"resets_at"`
+}
+
+func parseWindow(r *rawWindow) *Window {
+	if r == nil {
+		return nil
+	}
+	w := &Window{Utilization: r.Utilization}
+	if r.ResetsAtRaw != nil {
+		if t, err := time.Parse(time.RFC3339Nano, *r.ResetsAtRaw); err == nil {
+			w.ResetsAt = &t
+		}
+	}
+	return w
+}
+
+func (c *Client) stale(err error) (*Data, bool, error) {
+	c.mu.Lock()
+	last := c.lastGood
+	c.mu.Unlock()
+	if last != nil {
+		return last, true, nil
+	}
+	return nil, false, err
+}

--- a/internal/usage/client_test.go
+++ b/internal/usage/client_test.go
@@ -68,7 +68,7 @@ func TestClientFetchCaches(t *testing.T) {
 	if _, _, err := c.Fetch(t.Context()); err != nil {
 		t.Fatalf("setup fetch failed: %v", err)
 	}
-	c.Fetch(t.Context()) // should hit cache, not server
+	_, _, _ = c.Fetch(t.Context()) // should hit cache, not server
 
 	if calls != 1 {
 		t.Errorf("expected 1 HTTP call, got %d (caching not working)", calls)

--- a/internal/usage/client_test.go
+++ b/internal/usage/client_test.go
@@ -24,7 +24,9 @@ func makeServer(t *testing.T, fiveHourPct, sevenDayPct float64) *httptest.Server
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(payload)
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	}))
 }
 
@@ -56,12 +58,16 @@ func TestClientFetchCaches(t *testing.T) {
 			"five_hour": map[string]any{"utilization": 10.0, "resets_at": time.Now().Add(time.Hour).Format(time.RFC3339Nano)},
 			"seven_day": map[string]any{"utilization": 5.0, "resets_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339Nano)},
 		}
-		json.NewEncoder(w).Encode(payload)
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	}))
 	defer srv.Close()
 
 	c := usage.NewClient("tok", srv.URL)
-	c.Fetch(t.Context())
+	if _, _, err := c.Fetch(t.Context()); err != nil {
+		t.Fatalf("setup fetch failed: %v", err)
+	}
 	c.Fetch(t.Context()) // should hit cache, not server
 
 	if calls != 1 {
@@ -91,7 +97,9 @@ func TestClientFetchStaleOnError(t *testing.T) {
 				"five_hour": map[string]any{"utilization": 50.0, "resets_at": time.Now().Add(time.Hour).Format(time.RFC3339Nano)},
 				"seven_day": map[string]any{"utilization": 25.0, "resets_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339Nano)},
 			}
-			json.NewEncoder(w).Encode(payload)
+			if err := json.NewEncoder(w).Encode(payload); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 		} else {
 			http.Error(w, "error", http.StatusInternalServerError)
 		}
@@ -100,7 +108,9 @@ func TestClientFetchStaleOnError(t *testing.T) {
 
 	c := usage.NewClient("tok", srv.URL)
 	c.SetTTL(0) // bypass cache so second call hits server
-	c.Fetch(t.Context())
+	if _, _, err := c.Fetch(t.Context()); err != nil {
+		t.Fatalf("setup fetch failed: %v", err)
+	}
 	data, stale, err := c.Fetch(t.Context())
 	if err != nil {
 		t.Fatalf("expected stale fallback, got error: %v", err)

--- a/internal/usage/client_test.go
+++ b/internal/usage/client_test.go
@@ -1,0 +1,114 @@
+package usage_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Curt-Park/claudeview/internal/usage"
+)
+
+func makeServer(t *testing.T, fiveHourPct, sevenDayPct float64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{
+			"five_hour": map[string]any{
+				"utilization": fiveHourPct,
+				"resets_at":   time.Now().Add(2 * time.Hour).Format(time.RFC3339Nano),
+			},
+			"seven_day": map[string]any{
+				"utilization": sevenDayPct,
+				"resets_at":   time.Now().Add(5 * 24 * time.Hour).Format(time.RFC3339Nano),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(payload)
+	}))
+}
+
+func TestClientFetch(t *testing.T) {
+	srv := makeServer(t, 42.5, 18.0)
+	defer srv.Close()
+
+	c := usage.NewClient("test-token", srv.URL)
+	data, stale, err := c.Fetch(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stale {
+		t.Error("expected fresh result on first fetch")
+	}
+	if data.FiveHour == nil || data.FiveHour.Utilization != 42.5 {
+		t.Errorf("unexpected FiveHour: %v", data.FiveHour)
+	}
+	if data.SevenDay == nil || data.SevenDay.Utilization != 18.0 {
+		t.Errorf("unexpected SevenDay: %v", data.SevenDay)
+	}
+}
+
+func TestClientFetchCaches(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		payload := map[string]any{
+			"five_hour": map[string]any{"utilization": 10.0, "resets_at": time.Now().Add(time.Hour).Format(time.RFC3339Nano)},
+			"seven_day": map[string]any{"utilization": 5.0, "resets_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339Nano)},
+		}
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	c := usage.NewClient("tok", srv.URL)
+	c.Fetch(t.Context())
+	c.Fetch(t.Context()) // should hit cache, not server
+
+	if calls != 1 {
+		t.Errorf("expected 1 HTTP call, got %d (caching not working)", calls)
+	}
+}
+
+func TestClientFetchHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := usage.NewClient("tok", srv.URL)
+	_, _, err := c.Fetch(t.Context())
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+
+func TestClientFetchStaleOnError(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			payload := map[string]any{
+				"five_hour": map[string]any{"utilization": 50.0, "resets_at": time.Now().Add(time.Hour).Format(time.RFC3339Nano)},
+				"seven_day": map[string]any{"utilization": 25.0, "resets_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339Nano)},
+			}
+			json.NewEncoder(w).Encode(payload)
+		} else {
+			http.Error(w, "error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := usage.NewClient("tok", srv.URL)
+	c.SetTTL(0) // bypass cache so second call hits server
+	c.Fetch(t.Context())
+	data, stale, err := c.Fetch(t.Context())
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	if !stale {
+		t.Error("expected stale=true on second failing fetch")
+	}
+	if data == nil || data.FiveHour == nil {
+		t.Error("expected stale data to be non-nil")
+	}
+}

--- a/internal/usage/credentials.go
+++ b/internal/usage/credentials.go
@@ -1,0 +1,30 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type credentials struct {
+	ClaudeAiOauth struct {
+		AccessToken string `json:"accessToken"`
+	} `json:"claudeAiOauth"`
+}
+
+// ReadToken reads the OAuth access token from the given credentials file path.
+// Returns an error if the file is missing, malformed, or the token is empty.
+func ReadToken(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading credentials: %w", err)
+	}
+	var creds credentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return "", fmt.Errorf("parsing credentials: %w", err)
+	}
+	if creds.ClaudeAiOauth.AccessToken == "" {
+		return "", fmt.Errorf("no accessToken in credentials")
+	}
+	return creds.ClaudeAiOauth.AccessToken, nil
+}

--- a/internal/usage/credentials_test.go
+++ b/internal/usage/credentials_test.go
@@ -1,0 +1,49 @@
+package usage_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Curt-Park/claudeview/internal/usage"
+)
+
+func TestReadToken(t *testing.T) {
+	dir := t.TempDir()
+	creds := map[string]any{
+		"claudeAiOauth": map[string]any{
+			"accessToken": "test-token-abc",
+		},
+	}
+	data, _ := json.Marshal(creds)
+	path := filepath.Join(dir, ".credentials.json")
+	os.WriteFile(path, data, 0600)
+
+	token, err := usage.ReadToken(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "test-token-abc" {
+		t.Errorf("got %q, want %q", token, "test-token-abc")
+	}
+}
+
+func TestReadTokenMissingFile(t *testing.T) {
+	_, err := usage.ReadToken("/nonexistent/.credentials.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadTokenEmptyToken(t *testing.T) {
+	dir := t.TempDir()
+	creds := map[string]any{"claudeAiOauth": map[string]any{"accessToken": ""}}
+	data, _ := json.Marshal(creds)
+	os.WriteFile(filepath.Join(dir, ".credentials.json"), data, 0600)
+
+	_, err := usage.ReadToken(filepath.Join(dir, ".credentials.json"))
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}

--- a/internal/usage/credentials_test.go
+++ b/internal/usage/credentials_test.go
@@ -16,9 +16,14 @@ func TestReadToken(t *testing.T) {
 			"accessToken": "test-token-abc",
 		},
 	}
-	data, _ := json.Marshal(creds)
+	data, err := json.Marshal(creds)
+	if err != nil {
+		t.Fatalf("failed to marshal creds: %v", err)
+	}
 	path := filepath.Join(dir, ".credentials.json")
-	os.WriteFile(path, data, 0600)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("failed to write credentials file: %v", err)
+	}
 
 	token, err := usage.ReadToken(path)
 	if err != nil {
@@ -39,11 +44,30 @@ func TestReadTokenMissingFile(t *testing.T) {
 func TestReadTokenEmptyToken(t *testing.T) {
 	dir := t.TempDir()
 	creds := map[string]any{"claudeAiOauth": map[string]any{"accessToken": ""}}
-	data, _ := json.Marshal(creds)
-	os.WriteFile(filepath.Join(dir, ".credentials.json"), data, 0600)
+	data, err := json.Marshal(creds)
+	if err != nil {
+		t.Fatalf("failed to marshal creds: %v", err)
+	}
+	path := filepath.Join(dir, ".credentials.json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("failed to write credentials file: %v", err)
+	}
 
-	_, err := usage.ReadToken(filepath.Join(dir, ".credentials.json"))
+	_, err = usage.ReadToken(path)
 	if err == nil {
 		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestReadTokenMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".credentials.json")
+	if err := os.WriteFile(path, []byte("{bad json"), 0600); err != nil {
+		t.Fatalf("failed to write credentials file: %v", err)
+	}
+
+	_, err := usage.ReadToken(path)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a new `internal/usage` package: OAuth token reader, HTTP client with 60s TTL cache + stale fallback, and `█░` progress bar renderer
- Displays a 0–3 row usage panel above the info panel showing 5h/7d (and optional opus) window utilization with reset countdowns
- Dark background (`"238"`) matching the crumbs style; all inner lipgloss segments explicitly carry `Background(colorBg)` to prevent style-reset gaps
- Wired into `rootModel`: async refresh every 60 ticks; demo mode uses synthetic data via `demo.GenerateUsage()`

## Test Plan

- [x] Run `make test` — all 125+ tests pass
- [x] Run `make demo` — usage bar visible above info panel with synthetic 5h/8% and 7d/68% data
- [x] Run live — bar shows real utilization if `~/.claude/.credentials.json` is present; panel hidden if credentials are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)